### PR TITLE
feat/prepare removal of driver integration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 :artifactId: neo4j-cypher-dsl
 
 // This will be next version and also the one that will be put into the manual for the main branch
-:neo4j-cypher-dsl-version: 2024.5.2-SNAPSHOT
+:neo4j-cypher-dsl-version: 2024.6.0-SNAPSHOT
 // This is the latest released version, used only in the readme
 :neo4j-cypher-dsl-version-latest: 2024.5.1
 

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/src/test/java/org/neo4j/cypherdsl/examples/drivers/ExecutableStatementsIT.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/src/test/java/org/neo4j/cypherdsl/examples/drivers/ExecutableStatementsIT.java
@@ -55,7 +55,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * @author Michael J. Simons
  * @soundtrack Motörhead - Live At Brixton Academy
  */
-@Testcontainers(disabledWithoutDocker = true)
+@SuppressWarnings({ "removal", "deprecation" }) @Testcontainers(disabledWithoutDocker = true)
 class ExecutableStatementsIT {
 
 	@Container

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableResultStatement.java
@@ -39,6 +39,7 @@ import org.neo4j.driver.summary.ResultSummary;
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
  */
+@SuppressWarnings("removal")
 @API(status = INTERNAL, since = "2021.2.1")
 class DefaultExecutableResultStatement extends DefaultExecutableStatement implements ExecutableResultStatement {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableStatement.java
@@ -38,6 +38,7 @@ import org.neo4j.driver.summary.ResultSummary;
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
  */
+@SuppressWarnings("removal")
 @API(status = INTERNAL, since = "2021.2.1")
 class DefaultExecutableStatement implements ExecutableStatement {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableResultStatement.java
@@ -36,6 +36,7 @@ import org.reactivestreams.Publisher;
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
  */
+@SuppressWarnings("removal")
 @API(status = INTERNAL, since = "2021.2.1")
 class DefaultReactiveExecutableResultStatement extends DefaultReactiveExecutableStatement implements ReactiveExecutableResultStatement {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableStatement.java
@@ -33,6 +33,7 @@ import org.reactivestreams.Publisher;
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
  */
+@SuppressWarnings({ "removal" })
 @API(status = INTERNAL, since = "2021.2.1")
 class DefaultReactiveExecutableStatement extends DefaultExecutableStatement implements ReactiveExecutableStatement {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableResultStatement.java
@@ -38,7 +38,10 @@ import org.neo4j.driver.summary.ResultSummary;
  * @author Michael J. Simons
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
+ * @deprecated Without replacement, as there are other ideas bouncing around for plain object mapping from the common Neo4j Java Driver
  */
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public interface ExecutableResultStatement extends ExecutableStatement {
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableStatement.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core.executables;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import java.util.Collection;
 import java.util.Map;
@@ -58,8 +58,11 @@ import org.neo4j.driver.summary.ResultSummary;
  * @author Michael J. Simons
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
+ * @deprecated Without replacement, as there are other ideas bouncing around for plain object mapping from the common Neo4j Java Driver
  */
-@API(status = STABLE, since = "2021.2.1")
+@API(status = DEPRECATED, since = "2021.2.1")
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public interface ExecutableStatement {
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableResultStatement.java
@@ -33,7 +33,9 @@ import org.reactivestreams.Publisher;
  * @author Michael J. Simons
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
+ * @deprecated Without replacement, as there are other ideas bouncing around for plain object mapping from the common Neo4j Java Driver
  */
+@SuppressWarnings("removal") @Deprecated(forRemoval = true)
 public interface ReactiveExecutableResultStatement extends ReactiveExecutableStatement {
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableStatement.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core.executables;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.ResultStatement;
@@ -37,8 +37,11 @@ import org.reactivestreams.Publisher;
  * @author Michael J. Simons
  * @soundtrack Swiss + Die Andern - Randalieren für die Liebe
  * @since 2021.2.1
+ * @deprecated Without replacement, as there are other ideas bouncing around for plain object mapping from the common Neo4j Java Driver
  */
-@API(status = STABLE, since = "2021.2.1")
+@API(status = DEPRECATED, since = "2021.2.1")
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public interface ReactiveExecutableStatement extends ExecutableStatement {
 
 	/**


### PR DESCRIPTION
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump mockito.version from 5.16.0 to 5.16.1 (#1201)**
- **build(deps): Bump neo4j.version from 5.26.3 to 5.26.4 (#1202)**
- **build(deps-dev): Bump com.google.guava:guava (#1203)**
- **build(deps): Bump com.mycila:license-maven-plugin from 4.6 to 5.0.0 (#1204)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1205)**
- **build(deps): Bump net.java.dev.jna:jna from 5.16.0 to 5.17.0 (#1206)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1208)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1210)**
- **build(deps): Bump org.junit:junit-bom from 5.12.0 to 5.12.1 (#1209)**
- **build(deps): Bump testcontainers.version from 1.20.5 to 1.20.6 (#1207)**
- **refactor: Deprecate all driver integrations from Cypher-DSL side.**
