### PR TITLE
issue/1291

### DIFF
--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/pom.xml
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/pom.xml
@@ -44,11 +44,6 @@
 			<artifactId>javapoet</artifactId>
 		</dependency>
 		<dependency>
-			<!-- This is in provided scope of core. If not present here, the compiler will spit out warnings as it won't find all annotations -->
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl</artifactId>
 		</dependency>

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/pom.xml
@@ -39,11 +39,6 @@
 
 	<dependencies>
 		<dependency>
-			<!-- This is in provided scope of core. If not present here, the compiler will spit out warnings as it won't find all annotations -->
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl</artifactId>
 			<version>${revision}${sha1}${changelist}</version>

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-parser/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-parser/pom.xml
@@ -39,11 +39,6 @@
 
 	<dependencies>
 		<dependency>
-			<!-- This is in provided scope of core. If not present here, the compiler will spit out warnings as it won't find all annotations -->
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl</artifactId>
 			<version>${revision}${sha1}${changelist}</version>

--- a/neo4j-cypher-dsl-native-tests/pom.xml
+++ b/neo4j-cypher-dsl-native-tests/pom.xml
@@ -56,11 +56,6 @@
 			<artifactId>querydsl-core</artifactId>
 		</dependency>
 		<dependency>
-			<!-- This is in provided scope of core. If not present here, the compiler will spit out warnings as it won't find all annotations -->
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl-parser</artifactId>
 		</dependency>

--- a/neo4j-cypher-dsl-parser/pom.xml
+++ b/neo4j-cypher-dsl-parser/pom.xml
@@ -53,11 +53,6 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl</artifactId>
 		</dependency>
@@ -238,8 +233,6 @@
 							<overwriteExistingFiles>true</overwriteExistingFiles>
 							<module>
 								<moduleInfoSource><![CDATA[module org.neo4j.cypherdsl.parser {
-
-										requires static org.jetbrains.annotations;
 
 										requires transitive org.apiguardian.api;
 										requires transitive org.neo4j.cypherdsl.core;

--- a/neo4j-cypher-dsl-parser/src/main/java/module-info.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/module-info.java
@@ -23,7 +23,7 @@
 @SuppressWarnings( {"requires-automatic"}) // Neo4j Cypher Parser
 module org.neo4j.cypherdsl.parser {
 
-	requires static org.jetbrains.annotations;
+
 
 	requires transitive org.apiguardian.api;
 	requires transitive org.neo4j.cypherdsl.core;

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
@@ -34,8 +34,6 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypher.internal.ast.factory.ASTFactory;
 import org.neo4j.cypher.internal.ast.factory.ASTFactory.NULL;
 import org.neo4j.cypher.internal.parser.common.ast.factory.AccessType;
@@ -277,7 +275,7 @@ final class CypherDslASTFactory implements ASTFactory<
 		return (T) result;
 	}
 
-	private static SymbolicName assertSymbolicName(@Nullable Expression v) {
+	private static SymbolicName assertSymbolicName(Expression v) {
 
 		if (v == null) {
 			return null;
@@ -1154,7 +1152,6 @@ final class CypherDslASTFactory implements ASTFactory<
 		throw new UnsupportedOperationException("The Cypher-DSL does not support sensitive parameters.");
 	}
 
-	@NotNull
 	Parameter<?> parameterFromSymbolicName(Expression v) {
 		var symbolicName = assertSymbolicName(v);
 		if (symbolicName == null) {
@@ -1292,7 +1289,6 @@ final class CypherDslASTFactory implements ASTFactory<
 
 
 
-	@NotNull
 	private static LabelExpression colonJunjction(LabelExpression lhs, LabelExpression rhs, LabelExpression.Type colonDisjunction) {
 		List<String> value = new ArrayList<>();
 		value.addAll(lhs.value());

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/MatchDefinition.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/MatchDefinition.java
@@ -20,7 +20,6 @@ package org.neo4j.cypherdsl.parser;
 
 import java.util.List;
 
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Hint;
 import org.neo4j.cypherdsl.core.PatternElement;
 import org.neo4j.cypherdsl.core.Where;
@@ -37,6 +36,6 @@ import org.neo4j.cypherdsl.core.Where;
  */
 public record MatchDefinition(
 	boolean optional, List<PatternElement> patternElements,
-	@Nullable Where optionalWhere,
-	@Nullable List<Hint> optionalHints) {
+	Where optionalWhere,
+	List<Hint> optionalHints) {
 }

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/ReturnDefinition.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/ReturnDefinition.java
@@ -23,7 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.SortItem;
 
@@ -40,14 +39,14 @@ public final class ReturnDefinition {
 
 	private final boolean distinct;
 	private final List<Expression> expressions;
-	private final @Nullable List<SortItem> optionalSortItems;
-	private final @Nullable Expression optionalSkip;
-	private final @Nullable Expression optionalLimit;
+	private final List<SortItem> optionalSortItems;
+	private final Expression optionalSkip;
+	private final Expression optionalLimit;
 
 	ReturnDefinition(boolean distinct, List<Expression> expressions,
-		@Nullable List<SortItem> optionalSortItems,
-		@Nullable Expression optionalSkip,
-		@Nullable Expression optionalLimit) {
+		List<SortItem> optionalSortItems,
+		Expression optionalSkip,
+		Expression optionalLimit) {
 		this.distinct = distinct;
 		this.expressions = expressions;
 		this.optionalSortItems = optionalSortItems;

--- a/neo4j-cypher-dsl/pom.xml
+++ b/neo4j-cypher-dsl/pom.xml
@@ -55,10 +55,6 @@
 			<artifactId>apiguardian-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
 		</dependency>
@@ -185,8 +181,10 @@
 						<configuration combine.self="append">
 							<compilerArgs>
 								<arg>-Aquerydsl.generatedAnnotationClass=com.querydsl.core.annotations.Generated</arg>
-								<arg>-Xlint:all,-options,-path,-processing,-exports,-missing-explicit-ctor</arg>
+								<arg>-Xlint:all,-options,-path,-processing,-exports,-missing-explicit-ctor,-classfile</arg>
 								<arg>-Werror</arg>
+								<!-- Added because QueryDSL drags in Jetbrains annotation which we won't add explicitly. Goes together with -classfile. -->
+								<arg>-implicit:class</arg>
 							</compilerArgs>
 							<annotationProcessorPaths>
 								<annotationProcessorPath>

--- a/neo4j-cypher-dsl/src/main/java/module-info.java
+++ b/neo4j-cypher-dsl/src/main/java/module-info.java
@@ -25,7 +25,6 @@ module org.neo4j.cypherdsl.core {
 
 	requires static com.querydsl.core;
 	requires static java.sql;
-	requires static org.jetbrains.annotations;
 	requires static org.neo4j.cypherdsl.build.annotations;
 	requires static org.neo4j.driver;
 	requires static org.reactivestreams;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractCase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractCase.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.CaseElse;
 import org.neo4j.cypherdsl.core.internal.CaseWhenThen;
@@ -44,7 +42,7 @@ abstract class AbstractCase implements Case {
 	private Optional<String> prefix = Optional.empty();
 	private Optional<String> suffix = Optional.empty();
 
-	public static Case create(@Nullable Expression expression) {
+	public static Case create(Expression expression) {
 		return expression == null ? new GenericCaseImpl() : new SimpleCaseImpl(expression);
 	}
 
@@ -70,7 +68,7 @@ abstract class AbstractCase implements Case {
 	 * @return An ongoing when builder.
 	 */
 	@Override
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	public OngoingWhenThen when(Expression nextExpression) {
 
 		return new DefaultOngoingWhenThen(nextExpression);
@@ -86,7 +84,6 @@ abstract class AbstractCase implements Case {
 		return suffix;
 	}
 
-	@NotNull
 	@Override
 	public Property property(String... names) {
 
@@ -122,8 +119,7 @@ abstract class AbstractCase implements Case {
 				super(caseExpression, caseWhenThens);
 			}
 
-			@NotNull
-			@Override
+					@Override
 			public Case elseDefault(Expression defaultExpression) {
 				this.setCaseElse(new CaseElse(defaultExpression));
 				return this;
@@ -157,7 +153,7 @@ abstract class AbstractCase implements Case {
 
 			@Override
 			public
-			@NotNull Case elseDefault(Expression defaultExpression) {
+			Case elseDefault(Expression defaultExpression) {
 				this.setCaseElse(new CaseElse(defaultExpression));
 				return this;
 			}
@@ -195,7 +191,7 @@ abstract class AbstractCase implements Case {
 		 * @return An ongoing when builder.
 		 */
 		@Override
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		public CaseEnding then(Expression expression) {
 
 			CaseWhenThen caseWhenThen = new CaseWhenThen(whenExpression, expression);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
@@ -19,7 +19,6 @@
 package org.neo4j.cypherdsl.core;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
@@ -33,7 +32,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @API(status = INTERNAL, since = "2021.1.0")
 abstract class AbstractNode extends AbstractPropertyContainer implements Node {
 
-	@NotNull
 	@Override
 	public final Condition hasLabels(String... labelsToQuery) {
 		return HasLabelCondition.create(this.getSymbolicName()
@@ -41,7 +39,6 @@ abstract class AbstractNode extends AbstractPropertyContainer implements Node {
 				labelsToQuery);
 	}
 
-	@NotNull
 	@Override
 	public final Condition hasLabels(LabelExpression labels) {
 		return new HasLabelExpressionCondition(this.getSymbolicName()
@@ -49,81 +46,69 @@ abstract class AbstractNode extends AbstractPropertyContainer implements Node {
 			labels);
 	}
 
-	@NotNull
 	@Override
 	public final Condition isEqualTo(Node otherNode) {
 
 		return this.getRequiredSymbolicName().isEqualTo(otherNode.getRequiredSymbolicName());
 	}
 
-	@NotNull
 	@Override
 	public final Condition isNotEqualTo(Node otherNode) {
 
 		return this.getRequiredSymbolicName().isNotEqualTo(otherNode.getRequiredSymbolicName());
 	}
 
-	@NotNull
 	@Override
 	public final Condition isNull() {
 
 		return this.getRequiredSymbolicName().isNull();
 	}
 
-	@NotNull
 	@Override
 	public final Condition isNotNull() {
 
 		return this.getRequiredSymbolicName().isNotNull();
 	}
 
-	@NotNull
 	@Override
 	public final SortItem descending() {
 
 		return this.getRequiredSymbolicName().descending();
 	}
 
-	@NotNull
 	@Override
 	public final SortItem ascending() {
 
 		return this.getRequiredSymbolicName().ascending();
 	}
 
-	@NotNull
 	@Override
 	public final AliasedExpression as(String alias) {
 
 		return this.getRequiredSymbolicName().as(alias);
 	}
 
-	@NotNull
 	@Override
 	@SuppressWarnings("deprecation") // IDEA is stupid.
 	public final FunctionInvocation internalId() {
 		return Functions.id(this);
 	}
 
-	@NotNull
 	@Override
 	public final FunctionInvocation labels() {
 		return Functions.labels(this);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship relationshipTo(Node other, String... types) {
 		return new InternalRelationshipImpl(null, this, Relationship.Direction.LTR, null, other, types);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship relationshipFrom(Node other, String... types) {
 		return new InternalRelationshipImpl(null, this, Relationship.Direction.RTL, null, other, types);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship relationshipBetween(Node other, String... types) {
 		return new InternalRelationshipImpl(null, this, Relationship.Direction.UNI, null, other, types);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
@@ -19,7 +19,6 @@
 package org.neo4j.cypherdsl.core;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -34,21 +33,18 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @API(status = INTERNAL, since = "2021.1.0")
 abstract class AbstractPropertyContainer implements PropertyContainer {
 
-	@NotNull
 	@Override
-	public final Property property(@NotNull String name) {
+	public final Property property(String name) {
 		return InternalPropertyImpl.create(this, name);
 	}
 
-	@NotNull
 	@Override
 	public final Property property(String... names) {
 		return InternalPropertyImpl.create(this, names);
 	}
 
-	@NotNull
 	@Override
-	public final Property property(@NotNull Expression lookup) {
+	public final Property property(Expression lookup) {
 		return InternalPropertyImpl.create(this, lookup);
 	}
 
@@ -56,37 +52,31 @@ abstract class AbstractPropertyContainer implements PropertyContainer {
 		return new IllegalStateException(Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_REQUIRES_NAME_FOR_MUTATION));
 	}
 
-	@NotNull
 	@Override
 	public final Operation mutate(Parameter<?> parameter) {
 		return Operations.mutate(this.getSymbolicName().orElseThrow(AbstractPropertyContainer::noNameException), parameter);
 	}
 
-	@NotNull
 	@Override
 	public final Operation mutate(MapExpression properties) {
 		return Operations.mutate(this.getSymbolicName().orElseThrow(AbstractPropertyContainer::noNameException), properties);
 	}
 
-	@NotNull
 	@Override
 	public final Operation set(Parameter<?> parameter) {
 		return Operations.set(this.getSymbolicName().orElseThrow(AbstractPropertyContainer::noNameException), parameter);
 	}
 
-	@NotNull
 	@Override
 	public final Operation set(MapExpression properties) {
 		return Operations.set(this.getSymbolicName().orElseThrow(AbstractPropertyContainer::noNameException), properties);
 	}
 
-	@NotNull
 	@Override
 	public final MapProjection project(List<Object> entries) {
 		return project(entries.toArray());
 	}
 
-	@NotNull
 	@Override
 	public final MapProjection project(Object... entries) {
 		return getRequiredSymbolicName().project(entries);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractStatement.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.internal.DefaultStatementContext;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 
@@ -58,7 +57,6 @@ abstract class AbstractStatement implements Statement {
 	@SuppressWarnings("squid:S3077")
 	private volatile StatementCatalog statementCatalog;
 
-	@NotNull
 	@Override
 	public StatementContext getContext() {
 		return context;
@@ -79,7 +77,6 @@ abstract class AbstractStatement implements Statement {
 		}
 	}
 
-	@NotNull
 	@Override
 	public String getCypher() {
 
@@ -97,7 +94,6 @@ abstract class AbstractStatement implements Statement {
 	}
 
 	@Override
-	@NotNull
 	public StatementCatalog getCatalog() {
 
 		StatementCatalog result = this.statementCatalog;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Aliased.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Aliased.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An element with an alias. An alias has a subtle difference to a symbolic name in cypher. Nodes and relationships can
@@ -39,7 +37,6 @@ public interface Aliased {
 	/**
 	 * @return the alias.
 	 */
-	@NotNull @Contract(pure = true)
 	String getAlias();
 
 	/**
@@ -47,7 +44,6 @@ public interface Aliased {
 	 *
 	 * @return A new symbolic name
 	 */
-	@NotNull @Contract(pure = true)
 	default SymbolicName asName() {
 		return SymbolicName.of(this.getAlias());
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -44,7 +43,6 @@ public final class AliasedExpression implements Aliased, Expression, Identifiabl
 		this.alias = alias;
 	}
 
-	@NotNull
 	@Override
 	public String getAlias() {
 		return alias;
@@ -56,7 +54,6 @@ public final class AliasedExpression implements Aliased, Expression, Identifiabl
 	 * @param newAlias The new alias to use
 	 * @return A new aliased, expression.
 	 */
-	@NotNull
 	@Override
 	public AliasedExpression as(String newAlias) {
 
@@ -76,7 +73,6 @@ public final class AliasedExpression implements Aliased, Expression, Identifiabl
 		return delegate;
 	}
 
-	@NotNull
 	@Override
 	public Expression asExpression() {
 		return this;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * The {@code *}.
@@ -41,14 +40,12 @@ public final class Asterisk extends LiteralBase<String> implements IdentifiableE
 		super("*");
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 		return content;
 	}
 
 	@Override
-	@NotNull
 	public  Expression asExpression() {
 		return this;
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanLiteral.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * The boolean literal.
@@ -37,7 +35,7 @@ public final class BooleanLiteral extends LiteralBase<Boolean> {
 	static final BooleanLiteral TRUE = new BooleanLiteral(true);
 	static final BooleanLiteral FALSE = new BooleanLiteral(false);
 
-	static Literal<Boolean> of(@Nullable Boolean value) {
+	static Literal<Boolean> of(Boolean value) {
 
 		if (value != null && value) {
 			return TRUE;
@@ -50,7 +48,6 @@ public final class BooleanLiteral extends LiteralBase<Boolean> {
 		super(content);
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 		return getContent().toString();

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Case.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Case.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.ProvidesAffixes;
 import org.neo4j.cypherdsl.core.internal.CaseWhenThen;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
@@ -43,7 +41,7 @@ public interface Case extends Expression, ProvidesAffixes {
 	 * @param nextExpression The next expression to use.
 	 * @return An ongoing when builder.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	OngoingWhenThen when(Expression nextExpression);
 
 	/**
@@ -65,7 +63,7 @@ public interface Case extends Expression, ProvidesAffixes {
 	 * @param expression starting expression for the simple case
 	 * @return The new expression
 	 */
-	static Case create(@Nullable Expression expression) {
+	static Case create(Expression expression) {
 		return expression == null ? new AbstractCase.GenericCaseImpl() : new AbstractCase.SimpleCaseImpl(expression);
 	}
 
@@ -81,7 +79,7 @@ public interface Case extends Expression, ProvidesAffixes {
 		 * @param expression A new when expression.
 		 * @return An ongoing when builder.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingWhenThen when(Expression expression);
 
 		/**
@@ -90,7 +88,7 @@ public interface Case extends Expression, ProvidesAffixes {
 		 * @param defaultExpression The new default expression
 		 * @return An ongoing when builder.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		Case elseDefault(Expression defaultExpression);
 	}
 
@@ -106,7 +104,7 @@ public interface Case extends Expression, ProvidesAffixes {
 		 * @param expression The expression for the ongoing {@code WHEN} block.
 		 * @return An ongoing when builder.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		CaseEnding then(Expression expression);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.internal.LoadCSV;
 import org.neo4j.cypherdsl.core.internal.ProcedureName;
 import org.neo4j.cypherdsl.core.internal.YieldItems;
@@ -52,10 +50,9 @@ public final class Clauses {
 	 * @return an immutable match clause
 	 * @since 2022.0.0
 	 */
-	@NotNull
 	public static Clause match(boolean optional, List<PatternElement> patternElements,
-		@Nullable Where optionalWhere,
-		@Nullable List<Hint> optionalHints) {
+		Where optionalWhere,
+		List<Hint> optionalHints) {
 
 		return new Match(optional, Pattern.of(patternElements), optionalWhere, optionalHints);
 	}
@@ -67,7 +64,6 @@ public final class Clauses {
 	 * @param expressions The expressions pointing to the things to be deleted
 	 * @return an immutable delete clause
 	 */
-	@NotNull
 	public static Clause delete(boolean detach, List<Expression> expressions) {
 
 		return new Delete(new ExpressionList(expressions), detach);
@@ -83,10 +79,9 @@ public final class Clauses {
 	 * @param optionalLimit     an optional {@link NumberLiteral} of how many items to be returned
 	 * @return an immutable return clause
 	 */
-	@NotNull
 	public static Return returning(boolean distinct, List<Expression> expressions,
-		@Nullable List<SortItem> optionalSortItems,
-		@Nullable Expression optionalSkip, @Nullable Expression optionalLimit) {
+		List<SortItem> optionalSortItems,
+		Expression optionalSkip, Expression optionalLimit) {
 
 		DefaultStatementBuilder.OrderBuilder orderBuilder = new DefaultStatementBuilder.OrderBuilder();
 		orderBuilder.orderBy(optionalSortItems);
@@ -101,7 +96,6 @@ public final class Clauses {
 	 * @param patternElements The pattern elements to create
 	 * @return an immutable create clause
 	 */
-	@NotNull
 	public static Clause create(List<PatternElement> patternElements) {
 
 		return new Create(Pattern.of(patternElements));
@@ -114,8 +108,7 @@ public final class Clauses {
 	 * @param mergeActions    An optional list of {@link MergeAction merge actions}
 	 * @return an immutable merge clause
 	 */
-	@NotNull
-	public static Clause merge(List<PatternElement> patternElements, @Nullable List<MergeAction> mergeActions) {
+	public static Clause merge(List<PatternElement> patternElements, List<MergeAction> mergeActions) {
 
 		return new Merge(Pattern.of(patternElements), mergeActions == null ? Collections.emptyList() : mergeActions);
 	}
@@ -129,7 +122,7 @@ public final class Clauses {
 	 * @return an immutable with clause
 	 * @since 2022.0.0
 	 */
-	public static Clause with(Return returnClause, @Nullable Where optionalWhere) {
+	public static Clause with(Return returnClause, Where optionalWhere) {
 
 		return new With(returnClause, optionalWhere);
 	}
@@ -178,7 +171,7 @@ public final class Clauses {
 	 * @return an immutable clause
 	 */
 	public static Clause loadCSV(boolean withHeaders, StringLiteral uri, SymbolicName alias,
-		@Nullable String fieldTerminator) {
+		String fieldTerminator) {
 
 		return new LoadCSV(URI.create(uri.getContent().toString()), withHeaders, alias.getValue())
 			.withFieldTerminator(fieldTerminator);
@@ -195,8 +188,8 @@ public final class Clauses {
 	 * @return An immutable clause
 	 * @since 2022.0.0
 	 */
-	public static Clause callClause(List<String> namespace, String name, @Nullable List<Expression> arguments,
-		@Nullable List<Expression> resultItems, @Nullable Where optionalWhere) {
+	public static Clause callClause(List<String> namespace, String name, List<Expression> arguments,
+		List<Expression> resultItems, Where optionalWhere) {
 
 		return ProcedureCallImpl.create(ProcedureName.from(namespace, name),
 			new Arguments(arguments == null ? new Expression[0] : arguments.toArray(new Expression[0])),

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ClausesBasedStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ClausesBasedStatement.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.UsingPeriodicCommit;
@@ -44,7 +42,7 @@ class ClausesBasedStatement extends AbstractStatement {
 
 	private final List<Clause> clauses;
 
-	ClausesBasedStatement(@NotNull List<Clause> clauses, @Nullable UsingPeriodicCommit optionalPeriodicCommit) {
+	ClausesBasedStatement(List<Clause> clauses, UsingPeriodicCommit optionalPeriodicCommit) {
 		this.optionalPeriodicCommit = optionalPeriodicCommit;
 		this.clauses = List.copyOf(clauses);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CollectExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CollectExpression.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
 /**
@@ -49,7 +48,7 @@ public final class CollectExpression implements SubqueryExpression {
 		return new CollectExpression(new ImportingWith(), resultStatement);
 	}
 
-	static CollectExpression collect(@Nullable With optionalWith, Statement resultStatement) {
+	static CollectExpression collect(With optionalWith, Statement resultStatement) {
 		return new CollectExpression(new ImportingWith(optionalWith, null), resultStatement);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
@@ -22,7 +22,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.EnterResult;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
@@ -105,7 +104,6 @@ public final class Comparison implements Condition {
 	}
 
 
-	@NotNull
 	@Override
 	public Condition not() {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CompoundCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CompoundCondition.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.ProvidesAffixes;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
@@ -82,19 +81,16 @@ final class CompoundCondition implements Condition, ProvidesAffixes {
 		this.conditions = new ArrayList<>();
 	}
 
-	@NotNull
 	@Override
 	public Condition and(Condition condition) {
 		return this.add(Operator.AND, condition);
 	}
 
-	@NotNull
 	@Override
 	public Condition or(Condition condition) {
 		return this.add(Operator.OR, condition);
 	}
 
-	@NotNull
 	@Override
 	public Condition xor(Condition condition) {
 		return this.add(Operator.XOR, condition);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Condition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Condition.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 
 /**
@@ -40,7 +38,6 @@ public interface Condition extends Expression {
 	 * @param condition The new condition to add, must not be {@literal null}.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition and(Condition condition) {
 		return CompoundCondition.create(this, Operator.AND, condition);
 	}
@@ -51,7 +48,6 @@ public interface Condition extends Expression {
 	 * @param condition The new condition to add, must not be {@literal null}.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition or(Condition condition) {
 		return CompoundCondition.create(this, Operator.OR, condition);
 	}
@@ -62,7 +58,6 @@ public interface Condition extends Expression {
 	 * @param condition The new condition to add, must not be {@literal null}.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition xor(Condition condition) {
 		return CompoundCondition.create(this, Operator.XOR, condition);
 	}
@@ -77,7 +72,6 @@ public interface Condition extends Expression {
 	 * @return A new condition.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition and(RelationshipPattern pathPattern) {
 		return CompoundCondition.create(this, Operator.AND, RelationshipPatternCondition.of(pathPattern));
 	}
@@ -92,7 +86,6 @@ public interface Condition extends Expression {
 	 * @return A new condition.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition or(RelationshipPattern pathPattern) {
 		return CompoundCondition.create(this, Operator.OR, RelationshipPatternCondition.of(pathPattern));
 	}
@@ -107,7 +100,6 @@ public interface Condition extends Expression {
 	 * @return A new condition.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition xor(RelationshipPattern pathPattern) {
 		return CompoundCondition.create(this, Operator.XOR, RelationshipPatternCondition.of(pathPattern));
 	}
@@ -117,7 +109,6 @@ public interface Condition extends Expression {
 	 *
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition not() {
 		return Comparison.create(Operator.NOT, this);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Conditions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Conditions.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -149,8 +147,7 @@ final class Conditions {
 	 * @param condition The condition to negate. Must not be null.
 	 * @return The negated condition.
 	 */
-	@NotNull @Contract(pure = true)
-	static Condition not(@NotNull Condition condition) {
+	static Condition not(Condition condition) {
 
 		Assertions.notNull(condition, "Condition to negate must not be null.");
 		return condition.not();
@@ -162,8 +159,7 @@ final class Conditions {
 	 * @param pattern The pattern to negate. Must not be null.
 	 * @return A condition that evaluates to true when the pattern does not match.
 	 */
-	@NotNull @Contract(pure = true)
-	static Condition not(@NotNull RelationshipPattern pattern) {
+	static Condition not(RelationshipPattern pattern) {
 
 		return RelationshipPatternCondition.not(pattern);
 	}
@@ -207,7 +203,6 @@ final class Conditions {
 	 *
 	 * @return A placeholder condition.
 	 */
-	@NotNull @Contract(pure = true)
 	static Condition noCondition() {
 
 		return CompoundCondition.empty();

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConflictingParametersException.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConflictingParametersException.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Exception thrown when extracting parameters from a statement leads to one parameter with a given name appearing
@@ -58,7 +56,6 @@ public final class ConflictingParametersException extends RuntimeException {
 	/**
 	 * @return the conflicting parameters
 	 */
-	@NotNull @Contract(pure = true)
 	public Map<String, Set<Object>> getErroneousParameters() {
 		return Collections.unmodifiableMap(erroneousParameters);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CountExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CountExpression.java
@@ -23,14 +23,11 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
 /**
- * Added for supporting the Neo5j parser.
+ * Added for supporting the Neo4j v5 parser.
  *
  * @author Michael J. Simons
  * @soundtrack The Prodigy - Invaders Must Die
@@ -42,7 +39,6 @@ public final class CountExpression implements SubqueryExpression, ExposesWhere<E
 
 	private final ImportingWith importingWith;
 	private final List<Visitable> fragments;
-	@Nullable
 	private final Where innerWhere;
 
 	static CountExpression count(Statement statement, IdentifiableElement... imports) {
@@ -54,15 +50,15 @@ public final class CountExpression implements SubqueryExpression, ExposesWhere<E
 		return new CountExpression(new ImportingWith(), List.of(patternOrUnion), null);
 	}
 
-	static CountExpression count(@Nullable With optionalWith, Visitable patternOrUnion) {
+	static CountExpression count(With optionalWith, Visitable patternOrUnion) {
 		return new CountExpression(new ImportingWith(optionalWith, null), List.of(patternOrUnion), null);
 	}
 
-	static CountExpression count(List<PatternElement> patternElements, @Nullable Where innerWhere) {
+	static CountExpression count(List<PatternElement> patternElements, Where innerWhere) {
 		return new CountExpression(new ImportingWith(), patternElements, innerWhere);
 	}
 
-	private CountExpression(ImportingWith optionalWith, List<? extends Visitable> fragments, @Nullable Where innerWhere) {
+	private CountExpression(ImportingWith optionalWith, List<? extends Visitable> fragments, Where innerWhere) {
 
 		var patternOrUnion = fragments.size() == 1 ? fragments.get(0) : null;
 
@@ -90,7 +86,6 @@ public final class CountExpression implements SubqueryExpression, ExposesWhere<E
 	 * @param condition the condition to apply in the count expression
 	 * @return A new {@link CountExpression}
 	 */
-	@NotNull @Contract(pure = true)
 	public CountExpression where(Condition condition) {
 
 		if (fragments.size() == 1 && fragments.get(0) instanceof Statement) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -38,9 +38,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ListComprehension.OngoingDefinitionWithVariable;
 import org.neo4j.cypherdsl.core.Literal.UnsupportedLiteralException;
 import org.neo4j.cypherdsl.core.PatternComprehension.OngoingDefinitionWithPattern;
@@ -73,7 +70,6 @@ public final class Cypher {
 	 * @param additionalLabels Additional labels
 	 * @return A new node representation
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node node(String primaryLabel, String... additionalLabels) {
 
 		return new InternalNodeImpl(primaryLabel, additionalLabels);
@@ -87,7 +83,6 @@ public final class Cypher {
 	 * @param additionalLabels Additional labels
 	 * @return A new node representation
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node node(String primaryLabel, List<String> additionalLabels) {
 
 		return new InternalNodeImpl(primaryLabel, additionalLabels.toArray(new String[] {}));
@@ -103,7 +98,6 @@ public final class Cypher {
 	 * @param additionalLabels Additional labels
 	 * @return A new node representation
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node node(String primaryLabel, MapExpression properties, String... additionalLabels) {
 
 		return new InternalNodeImpl(null, primaryLabel, properties, additionalLabels);
@@ -120,7 +114,6 @@ public final class Cypher {
 	 * @return A new node representation
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node node(String primaryLabel, MapExpression properties, Collection<String> additionalLabels) {
 
 		return node(primaryLabel, properties, additionalLabels.toArray(new String[] {}));
@@ -129,7 +122,6 @@ public final class Cypher {
 	/**
 	 * @return A node matching any node.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node anyNode() {
 		return new InternalNodeImpl();
 	}
@@ -139,7 +131,6 @@ public final class Cypher {
 	 * @return A node matching a label expression
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node node(LabelExpression labelExpression) {
 		return new InternalNodeImpl(Objects.requireNonNull(labelExpression), null);
 	}
@@ -147,7 +138,6 @@ public final class Cypher {
 	/**
 	 * @return The {@code *} wildcard literal.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Asterisk asterisk() {
 		return Asterisk.INSTANCE;
 	}
@@ -156,7 +146,6 @@ public final class Cypher {
 	 * @param symbolicName The new symbolic name
 	 * @return A node matching any node with the symbolic the given {@code symbolicName}.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node anyNode(String symbolicName) {
 		return new InternalNodeImpl().named(symbolicName);
 	}
@@ -165,7 +154,6 @@ public final class Cypher {
 	 * @param symbolicName The new symbolic name
 	 * @return A node matching any node with the symbolic the given {@code symbolicName}.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Node anyNode(SymbolicName symbolicName) {
 		return new InternalNodeImpl().named(symbolicName);
 	}
@@ -178,7 +166,6 @@ public final class Cypher {
 	 *                      like {@code containerName.name1.name2}.
 	 * @return A new property
 	 */
-	@NotNull @Contract(pure = true)
 	public static Property property(String containerName, String... names) {
 		return property(name(containerName), names);
 	}
@@ -192,7 +179,6 @@ public final class Cypher {
 	 * @return A new property
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static Property property(String containerName, Collection<String> names) {
 		return property(name(containerName), names.toArray(new String[] {}));
 	}
@@ -205,7 +191,6 @@ public final class Cypher {
 	 *                   like {@code expression.name1.name2}.
 	 * @return A new property.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Property property(Expression expression, String... names) {
 		return InternalPropertyImpl.create(expression, names);
 	}
@@ -219,7 +204,6 @@ public final class Cypher {
 	 * @return A new property.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static Property property(Expression expression, Collection<String> names) {
 		return property(expression, names.toArray(new String[] {}));
 	}
@@ -233,7 +217,6 @@ public final class Cypher {
 	 * @return A new property
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Property property(String containerName, Expression lookup) {
 		return property(name(containerName), lookup);
 	}
@@ -247,7 +230,6 @@ public final class Cypher {
 	 * @return A new property.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Property property(Expression expression, Expression lookup) {
 		return InternalPropertyImpl.create(expression, lookup);
 	}
@@ -259,7 +241,6 @@ public final class Cypher {
 	 * @return An ongoing definition of a named path
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static NamedPath.OngoingDefinitionWithName path(String name) {
 		return NamedPath.named(name);
 	}
@@ -271,7 +252,6 @@ public final class Cypher {
 	 * @return An ongoing definition of a named path
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static NamedPath.OngoingDefinitionWithName path(SymbolicName name) {
 		return NamedPath.named(name);
 	}
@@ -314,7 +294,6 @@ public final class Cypher {
 	 * @param value The value of the symbolic name
 	 * @return A new symbolic name
 	 */
-	@NotNull @Contract(pure = true)
 	public static SymbolicName name(String value) {
 
 		return SymbolicName.of(value);
@@ -326,7 +305,6 @@ public final class Cypher {
 	 * @param name The name of the parameter, must not be null
 	 * @return The new parameter
 	 */
-	@NotNull @Contract(pure = true)
 	public static Parameter<Object> parameter(String name) {
 		return Parameter.create(name);
 	}
@@ -341,7 +319,6 @@ public final class Cypher {
 	 * @return The new parameter
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static <T> Parameter<T> parameter(String name, T value) {
 		return Parameter.create(name, value);
 	}
@@ -355,7 +332,6 @@ public final class Cypher {
 	 * @return The new parameter
 	 * @since 2021.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static <T> Parameter<T> anonParameter(T value) {
 		return Parameter.anon(value);
 	}
@@ -366,7 +342,6 @@ public final class Cypher {
 	 * @param pattern The patterns to match
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere optionalMatch(PatternElement... pattern) {
 
 		return Statement.builder().optionalMatch(pattern);
@@ -379,7 +354,6 @@ public final class Cypher {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere optionalMatch(
 		Collection<? extends PatternElement> pattern) {
 
@@ -393,7 +367,6 @@ public final class Cypher {
 	 * @param pattern The patterns to match
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere match(PatternElement... pattern) {
 
 		return Statement.builder().match(pattern);
@@ -407,7 +380,6 @@ public final class Cypher {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere match(Collection<? extends PatternElement> pattern) {
 
 		return match(pattern.toArray(new PatternElement[] {}));
@@ -422,7 +394,6 @@ public final class Cypher {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2020.1.3
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere match(boolean optional, PatternElement... pattern) {
 
 		return Statement.builder().match(optional, pattern);
@@ -437,7 +408,6 @@ public final class Cypher {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere match(boolean optional,
 		Collection<? extends PatternElement> pattern) {
 
@@ -450,7 +420,6 @@ public final class Cypher {
 	 * @param pattern The patterns to create
 	 * @return An ongoing {@code CREATE} that can be used to specify {@code WITH} and {@code RETURNING} etc.
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingUpdate create(PatternElement... pattern) {
 
 		return Statement.builder().create(pattern);
@@ -463,7 +432,6 @@ public final class Cypher {
 	 * @return An ongoing {@code CREATE} that can be used to specify {@code WITH} and {@code RETURNING} etc.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 
 		return create(pattern.toArray(new PatternElement[] {}));
@@ -478,7 +446,6 @@ public final class Cypher {
 	 * @return An ongoing with clause.
 	 * @since 2020.1.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
 
 		return Statement.builder().with(variables);
@@ -493,7 +460,6 @@ public final class Cypher {
 	 * @return An ongoing with clause.
 	 * @since 2020.1.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(IdentifiableElement... elements) {
 
 		return Statement.builder().with(elements);
@@ -533,7 +499,6 @@ public final class Cypher {
 	 * @return An ongoing with clause.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(
 		Collection<IdentifiableElement> elements) {
 
@@ -546,7 +511,6 @@ public final class Cypher {
 	 * @param pattern The patterns to merge
 	 * @return An ongoing {@code MERGE} that can be used to specify {@code WITH} and {@code RETURNING} etc.
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingMerge merge(PatternElement... pattern) {
 
 		return Statement.builder().merge(pattern);
@@ -559,7 +523,6 @@ public final class Cypher {
 	 * @return An ongoing {@code MERGE} that can be used to specify {@code WITH} and {@code RETURNING} etc.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingMerge merge(Collection<? extends PatternElement> pattern) {
 
 		return merge(pattern.toArray(new PatternElement[] {}));
@@ -572,7 +535,6 @@ public final class Cypher {
 	 * @param expression The expression to unwind
 	 * @return An ongoing {@code UNWIND}.
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingUnwind unwind(Expression expression) {
 
 		return Statement.builder().unwind(expression);
@@ -585,7 +547,6 @@ public final class Cypher {
 	 * @param expressions expressions to unwind
 	 * @return a new instance of {@link StatementBuilder.OngoingUnwind}
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingUnwind unwind(Expression... expressions) {
 
 		return Statement.builder().unwind(Cypher.listOf(expressions));
@@ -599,7 +560,6 @@ public final class Cypher {
 	 * @return a new instance of {@link StatementBuilder.OngoingUnwind}
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingUnwind unwind(Collection<? extends Expression> expressions) {
 
 		return unwind(expressions.toArray(new Expression[] {}));
@@ -611,7 +571,6 @@ public final class Cypher {
 	 * @param expression The expression by which things should be sorted
 	 * @return A sort item, providing means to specify ascending or descending order
 	 */
-	@NotNull @Contract(pure = true)
 	public static SortItem sort(Expression expression) {
 
 		return SortItem.create(expression, null);
@@ -625,7 +584,6 @@ public final class Cypher {
 	 * @return A sort item
 	 * @since 2021.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static SortItem sort(Expression expression, SortItem.Direction direction) {
 
 		return SortItem.create(expression, direction);
@@ -637,7 +595,6 @@ public final class Cypher {
 	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}
 	 * @return A new map expression.
 	 */
-	@NotNull @Contract(pure = true)
 	public static MapExpression mapOf(Object... keysAndValues) {
 
 		return MapExpression.create(false, keysAndValues);
@@ -649,7 +606,6 @@ public final class Cypher {
 	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}
 	 * @return A new map expression.
 	 */
-	@NotNull @Contract(pure = true)
 	public static MapExpression sortedMapOf(Object... keysAndValues) {
 
 		return MapExpression.create(true, keysAndValues);
@@ -662,7 +618,6 @@ public final class Cypher {
 	 * @return A new map expression.
 	 * @since 2021.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static MapExpression asExpression(Map<String, Object> map) {
 
 		return MapExpression.create(map);
@@ -674,7 +629,6 @@ public final class Cypher {
 	 * @param expressions expressions to get combined into a list
 	 * @return a new instance of {@link ListExpression}
 	 */
-	@NotNull @Contract(pure = true)
 	public static ListExpression listOf(Expression... expressions) {
 
 		return ListExpression.create(expressions);
@@ -687,7 +641,6 @@ public final class Cypher {
 	 * @return a new instance of {@link ListExpression}
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static ListExpression listOf(Collection<? extends Expression> expressions) {
 
 		return Cypher.listOf(expressions.toArray(new Expression[0]));
@@ -702,7 +655,6 @@ public final class Cypher {
 	 * @throws UnsupportedLiteralException when the object cannot be represented as a literal
 	 */
 	@SuppressWarnings("unchecked")
-	@NotNull @Contract(pure = true)
 	public static <T> Literal<T> literalOf(Object object) {
 
 		if (object == null) {
@@ -783,7 +735,6 @@ public final class Cypher {
 	/**
 	 * @return The {@literal true} literal.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Literal<Boolean> literalTrue() {
 		return BooleanLiteral.TRUE;
 	}
@@ -791,7 +742,6 @@ public final class Cypher {
 	/**
 	 * @return The {@literal false} literal.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Literal<Boolean> literalFalse() {
 		return BooleanLiteral.FALSE;
 	}
@@ -799,7 +749,6 @@ public final class Cypher {
 	/**
 	 * @return The {@literal null} literal.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Literal<Void> literalNull() {
 		return NullLiteral.INSTANCE;
 	}
@@ -810,7 +759,6 @@ public final class Cypher {
 	 * @param statements the statements to union.
 	 * @return A union statement.
 	 */
-	@NotNull @Contract(pure = true)
 	public static UnionQuery union(Statement... statements) {
 		return unionImpl(false, statements);
 	}
@@ -822,7 +770,6 @@ public final class Cypher {
 	 * @return A union statement.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static UnionQuery union(Collection<Statement> statements) {
 		return union(statements.toArray(new Statement[] {}));
 	}
@@ -833,7 +780,6 @@ public final class Cypher {
 	 * @param statements the statements to union.
 	 * @return A union statement.
 	 */
-	@NotNull @Contract(pure = true)
 	public static Statement unionAll(Statement... statements) {
 		return unionImpl(true, statements);
 	}
@@ -845,7 +791,6 @@ public final class Cypher {
 	 * @return A union statement.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static Statement unionAll(Collection<Statement> statements) {
 		return unionAll(statements.toArray(new Statement[] {}));
 	}
@@ -857,7 +802,6 @@ public final class Cypher {
 	 * @return A buildable statement
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingAndReturn returning(Expression... expressions) {
 		return Statement.builder().returning(expressions);
 	}
@@ -869,7 +813,6 @@ public final class Cypher {
 	 * @return A buildable statement
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 		return Statement.builder().returning(expressions);
 	}
@@ -881,7 +824,6 @@ public final class Cypher {
 	 * @return An ongoing definition.
 	 * @since 2020.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static OngoingDefinitionWithPattern listBasedOn(RelationshipPattern relationshipPattern) {
 		return PatternComprehension.basedOn(relationshipPattern);
 	}
@@ -893,7 +835,6 @@ public final class Cypher {
 	 * @return An ongoing definition.
 	 * @since 2020.1.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static OngoingDefinitionWithPattern listBasedOn(NamedPath namedPath) {
 		return PatternComprehension.basedOn(namedPath);
 	}
@@ -905,7 +846,6 @@ public final class Cypher {
 	 * @return An ongoing definition of a list comprehension
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static OngoingDefinitionWithVariable listWith(SymbolicName variable) {
 		return ListComprehension.with(variable);
 	}
@@ -916,7 +856,6 @@ public final class Cypher {
 	 * @param unquotedString An unquoted string
 	 * @return A quoted string with special chars escaped.
 	 */
-	@NotNull @Contract(pure = true)
 	public static String quote(String unquotedString) {
 		return literalOf(unquotedString).asString();
 	}
@@ -924,7 +863,6 @@ public final class Cypher {
 	/**
 	 * @return generic case expression start
 	 */
-	@NotNull @Contract(pure = true)
 	public static Case caseExpression() {
 		return Case.create(null);
 	}
@@ -933,8 +871,7 @@ public final class Cypher {
 	 * @param expression initial expression for the simple case statement
 	 * @return simple case expression start
 	 */
-	@NotNull @Contract(pure = true)
-	public static Case caseExpression(@Nullable Expression expression) {
+	public static Case caseExpression(Expression expression) {
 		return Case.create(expression);
 	}
 
@@ -945,7 +882,6 @@ public final class Cypher {
 	 * @param procedureName The procedure name of the procedure to call. Might be fully qualified.
 	 * @return An ongoing definition of a call
 	 */
-	@NotNull @Contract(pure = true)
 	public static OngoingStandaloneCallWithoutArguments call(String procedureName) {
 
 		Assertions.hasText(procedureName, "The procedure name must not be null or empty.");
@@ -958,7 +894,6 @@ public final class Cypher {
 	 * @param namespaceAndProcedure The procedure name of the procedure to call.
 	 * @return An ongoing definition of a call
 	 */
-	@NotNull @Contract(pure = true)
 	public static OngoingStandaloneCallWithoutArguments call(String... namespaceAndProcedure) {
 		return Statement.call(namespaceAndProcedure);
 	}
@@ -970,7 +905,6 @@ public final class Cypher {
 	 * @return An ongoing definition of a call
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static OngoingStandaloneCallWithoutArguments call(Collection<String> namespaceAndProcedure) {
 		return call(namespaceAndProcedure.toArray(new String[] {}));
 	}
@@ -985,7 +919,6 @@ public final class Cypher {
 	 * @since 2020.1.2
 	 */
 	@Neo4jVersion(minimum = "4.0.0")
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingWithoutWhere call(Statement subquery) {
 		return Statement.builder().call(subquery);
 	}
@@ -999,7 +932,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression subList(Expression targetExpression, Integer start, Integer end) {
 
 		return ListOperator.subList(targetExpression, Cypher.literalOf(start), Cypher.literalOf(end));
@@ -1014,7 +946,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression subList(Expression targetExpression, Expression start, Expression end) {
 
 		return ListOperator.subList(targetExpression, start, end);
@@ -1028,7 +959,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression subListFrom(Expression targetExpression, Integer start) {
 
 		return ListOperator.subListFrom(targetExpression, Cypher.literalOf(start));
@@ -1042,7 +972,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression subListFrom(Expression targetExpression, Expression start) {
 
 		return ListOperator.subListFrom(targetExpression, start);
@@ -1056,7 +985,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression subListUntil(Expression targetExpression, Integer end) {
 
 		return ListOperator.subListUntil(targetExpression, Cypher.literalOf(end));
@@ -1070,7 +998,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression subListUntil(Expression targetExpression, Expression end) {
 
 		return ListOperator.subListUntil(targetExpression, end);
@@ -1084,7 +1011,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static ListOperator valueAt(Expression targetExpression, Integer index) {
 
 		return valueAt(targetExpression, Cypher.literalOf(index));
@@ -1098,7 +1024,6 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static ListOperator valueAt(Expression targetExpression, Expression index) {
 
 		return ListOperator.valueAt(targetExpression, index);
@@ -1117,7 +1042,6 @@ public final class Cypher {
 	 * @return An expression to reuse with the builder.
 	 * @since 2021.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	public static Expression raw(String format, Object... mixedArgs) {
 
 		return RawLiteral.create(format, mixedArgs);
@@ -1145,7 +1069,6 @@ public final class Cypher {
 	 * @return A match that can be build now
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingAndReturn returningRaw(Expression rawExpression) {
 		return Statement.builder().returningRaw(rawExpression);
 	}
@@ -1167,7 +1090,6 @@ public final class Cypher {
 	 * @throws IllegalArgumentException in case the object cannot be adapter
 	 * @since 2021.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	public static <FE> ForeignAdapter<FE> adapt(FE expression) {
 
 		ForeignAdapterFactory initializedForeignAdapterFactory = foreignAdapterFactory;
@@ -1189,7 +1111,6 @@ public final class Cypher {
 	 * @return An ongoing definition of a {@code LOAD CSV} clause
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
 	public static ExposesLoadCSV usingPeriodicCommit() {
 
 		return usingPeriodicCommit(null);
@@ -1202,8 +1123,7 @@ public final class Cypher {
 	 * @return An ongoing definition of a {@code LOAD CSV} clause
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	public static ExposesLoadCSV usingPeriodicCommit(@Nullable Integer rate) {
+	public static ExposesLoadCSV usingPeriodicCommit(Integer rate) {
 
 		return LoadCSVStatementBuilder.usingPeriodicCommit(rate);
 	}
@@ -1451,8 +1371,7 @@ public final class Cypher {
 	 * @return The negated condition.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static Condition not(@NotNull Condition condition) {
+	public static Condition not(Condition condition) {
 		return Conditions.not(condition);
 	}
 
@@ -1463,8 +1382,7 @@ public final class Cypher {
 	 * @return A condition that evaluates to true when the pattern does not match.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static Condition not(@NotNull RelationshipPattern pattern) {
+	public static Condition not(RelationshipPattern pattern) {
 		return Conditions.not(pattern);
 	}
 
@@ -1511,7 +1429,6 @@ public final class Cypher {
 	 * @return A placeholder condition.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static Condition noCondition() {
 		return Conditions.noCondition();
 	}
@@ -1586,7 +1503,6 @@ public final class Cypher {
 	 * @return the immutable {@link CountExpression}
 	 * @since 2023.9.0
 	 */
-	@NotNull
 	public static CountExpression count(PatternElement requiredPattern, PatternElement... patternElement) {
 		return Expressions.count(requiredPattern, patternElement);
 	}
@@ -1598,7 +1514,6 @@ public final class Cypher {
 	 * @return the immutable {@link CountExpression}
 	 * @since 2023.9.0
 	 */
-	@NotNull
 	public static CountExpression count(UnionQuery union) {
 		return Expressions.count(union);
 	}
@@ -1613,7 +1528,6 @@ public final class Cypher {
 	 * @return a counting sub-query.
 	 * @since 2023.9.0
 	 */
-	@NotNull
 	public static CountExpression count(Statement statement, IdentifiableElement... imports) {
 		return Expressions.count(statement, imports);
 	}
@@ -1626,7 +1540,7 @@ public final class Cypher {
 	 * @return a count expression.
 	 * @since 2023.9.0
 	 */
-	public static CountExpression count(List<PatternElement> pattern, @Nullable Where where) {
+	public static CountExpression count(List<PatternElement> pattern, Where where) {
 		return Expressions.count(pattern, where);
 	}
 
@@ -1639,7 +1553,7 @@ public final class Cypher {
 	 * @return a collecting sub-query.
 	 * @since 2023.9.0
 	 */
-	@NotNull public static Expression collect(Statement statement) {
+	public static Expression collect(Statement statement) {
 		return Expressions.collect(statement);
 	}
 
@@ -1667,8 +1581,7 @@ public final class Cypher {
 	 * @return a function call for {@code elementId()} on a node.
 	 * @since 2023.9.0
 	 */
-	@Neo4jVersion(minimum = "5.0.0") @Contract(pure = true) @NotNull
-	public static FunctionInvocation elementId(Node node) {
+	@Neo4jVersion(minimum = "5.0.0") public static FunctionInvocation elementId(Node node) {
 		return Functions.elementId(node);
 	}
 
@@ -1679,8 +1592,7 @@ public final class Cypher {
 	 * @return A function call for {@code elementId()} on a relationship.
 	 * @since 2023.9.0
 	 */
-	@Neo4jVersion(minimum = "5.0.0") @Contract(pure = true) @NotNull
-	public static FunctionInvocation elementId(Relationship relationship) {
+	@Neo4jVersion(minimum = "5.0.0") public static FunctionInvocation elementId(Relationship relationship) {
 		return Functions.elementId(relationship);
 	}
 
@@ -1692,8 +1604,7 @@ public final class Cypher {
 	 * @return A function call for {@code keys()} on an expression.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation keys(@NotNull Node node) {
+	public static FunctionInvocation keys(Node node) {
 		return Functions.keys(node);
 	}
 
@@ -1705,8 +1616,7 @@ public final class Cypher {
 	 * @return A function call for {@code keys()} on an expression.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation keys(@NotNull Relationship relationship) {
+	public static FunctionInvocation keys(Relationship relationship) {
 		return Functions.keys(relationship);
 	}
 
@@ -1718,8 +1628,7 @@ public final class Cypher {
 	 * @return A function call for {@code keys()} on an expression.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation keys(@NotNull Expression expression) {
+	public static FunctionInvocation keys(Expression expression) {
 		return Functions.keys(expression);
 	}
 
@@ -1731,8 +1640,7 @@ public final class Cypher {
 	 * @return A function call for {@code labels()} on a node.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation labels(@NotNull Node node) {
+	public static FunctionInvocation labels(Node node) {
 		return Functions.labels(node);
 	}
 
@@ -1746,8 +1654,7 @@ public final class Cypher {
 	 * @return A function call for {@code labels()} on a node.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation labels(@NotNull SymbolicName node) {
+	public static FunctionInvocation labels(SymbolicName node) {
 		return Functions.labels(node);
 	}
 
@@ -1759,8 +1666,7 @@ public final class Cypher {
 	 * @return A function call for {@code type()} on a relationship.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation type(@NotNull Relationship relationship) {
+	public static FunctionInvocation type(Relationship relationship) {
 		return Functions.type(relationship);
 	}
 
@@ -1774,8 +1680,7 @@ public final class Cypher {
 	 * @return A function call for {@code type()} on a relationship.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation type(@NotNull SymbolicName relationship) {
+	public static FunctionInvocation type(SymbolicName relationship) {
 		return Functions.type(relationship);
 	}
 
@@ -1785,8 +1690,7 @@ public final class Cypher {
 	 * @see #count(Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation count(@NotNull Node node) {
+	public static FunctionInvocation count(Node node) {
 		return Functions.count(node);
 	}
 
@@ -1798,7 +1702,6 @@ public final class Cypher {
 	 * @return A function call for {@code count()} for an expression like {@link Cypher#asterisk()} etc.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation count(Expression expression) {
 		return Functions.count(expression);
 	}
@@ -1811,8 +1714,7 @@ public final class Cypher {
 	 * @see #countDistinct(Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation countDistinct(@NotNull Node node) {
+	public static FunctionInvocation countDistinct(Node node) {
 		return Functions.countDistinct(node);
 	}
 
@@ -1824,7 +1726,6 @@ public final class Cypher {
 	 * @return A function call for {@code count()} for an expression like {@link Cypher#asterisk()} etc.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation countDistinct(Expression expression) {
 		return Functions.countDistinct(expression);
 	}
@@ -1836,7 +1737,6 @@ public final class Cypher {
 	 * @return A function call for {@code properties())}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation properties(Node node) {
 		return Functions.properties(node);
 	}
@@ -1848,7 +1748,6 @@ public final class Cypher {
 	 * @return A function call for {@code properties())}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation properties(Relationship relationship) {
 		return Functions.properties(relationship);
 	}
@@ -1860,7 +1759,6 @@ public final class Cypher {
 	 * @return A function call for {@code properties())}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation properties(MapExpression map) {
 		return Functions.properties(map);
 	}
@@ -1873,7 +1771,6 @@ public final class Cypher {
 	 * @return A function call for {@code coalesce}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation coalesce(Expression... expressions) {
 		return Functions.coalesce(expressions);
 	}
@@ -1887,7 +1784,6 @@ public final class Cypher {
 	 * @return A function call for {@code left()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation left(Expression expression, Expression length) {
 		return Functions.left(expression, length);
 	}
@@ -1900,8 +1796,7 @@ public final class Cypher {
 	 * @return A function call for {@code ltrim()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation ltrim(@NotNull Expression expression) {
+	public static FunctionInvocation ltrim(Expression expression) {
 		return Functions.ltrim(expression);
 	}
 
@@ -1915,7 +1810,6 @@ public final class Cypher {
 	 * @return A function call for {@code replace()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation replace(Expression original, Expression search, Expression replace) {
 		return Functions.replace(original, search, replace);
 	}
@@ -1928,8 +1822,7 @@ public final class Cypher {
 	 * @return A function call for {@code reverse()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation reverse(@NotNull Expression original) {
+	public static FunctionInvocation reverse(Expression original) {
 		return Functions.reverse(original);
 	}
 
@@ -1942,7 +1835,6 @@ public final class Cypher {
 	 * @return A function call for {@code right()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation right(Expression expression, Expression length) {
 		return Functions.right(expression, length);
 	}
@@ -1955,8 +1847,7 @@ public final class Cypher {
 	 * @return A function call for {@code rtrim()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation rtrim(@NotNull Expression expression) {
+	public static FunctionInvocation rtrim(Expression expression) {
 		return Functions.rtrim(expression);
 	}
 
@@ -1970,7 +1861,6 @@ public final class Cypher {
 	 * @return A function call for {@code substring()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation substring(Expression original, Expression start,
 		Expression length) {
 		return Functions.substring(original, start, length);
@@ -1984,8 +1874,7 @@ public final class Cypher {
 	 * @return A function call for {@code toLower()} for one expression
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toLower(@NotNull Expression expression) {
+	public static FunctionInvocation toLower(Expression expression) {
 		return Functions.toLower(expression);
 	}
 
@@ -1997,8 +1886,7 @@ public final class Cypher {
 	 * @return A function call for {@code toLower()} for one expression
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toUpper(@NotNull Expression expression) {
+	public static FunctionInvocation toUpper(Expression expression) {
 		return Functions.toUpper(expression);
 	}
 
@@ -2010,8 +1898,7 @@ public final class Cypher {
 	 * @return A function call for {@code trim()} for one expression
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation trim(@NotNull Expression expression) {
+	public static FunctionInvocation trim(Expression expression) {
 		return Functions.trim(expression);
 	}
 
@@ -2024,9 +1911,8 @@ public final class Cypher {
 	 * @return A function call for {@code split()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation split(@NotNull Expression expression,
-		@NotNull Expression delimiter) {
+	public static FunctionInvocation split(Expression expression,
+		Expression delimiter) {
 		return Functions.split(expression, delimiter);
 	}
 
@@ -2039,9 +1925,8 @@ public final class Cypher {
 	 * @return A function call for {@code split()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation split(@NotNull Expression expression,
-		@NotNull String delimiter) {
+	public static FunctionInvocation split(Expression expression,
+		String delimiter) {
 		return Functions.split(expression, delimiter);
 	}
 
@@ -2056,7 +1941,6 @@ public final class Cypher {
 	 * @return A function call for {@code size()} for one expression
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation size(Expression expression) {
 		return Functions.size(expression);
 	}
@@ -2071,7 +1955,6 @@ public final class Cypher {
 	 * @return A function call for {@code size()} for a pattern
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation size(RelationshipPattern pattern) {
 		return Functions.size(pattern);
 	}
@@ -2084,7 +1967,6 @@ public final class Cypher {
 	 * @return A function call for {@code exists()} for one expression
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation exists(Expression expression) {
 		return Functions.exists(expression);
 	}
@@ -2099,9 +1981,8 @@ public final class Cypher {
 	 * @return A function call for {@code distance()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation distance(@NotNull Expression point1,
-		@NotNull Expression point2) {
+	public static FunctionInvocation distance(Expression point1,
+		Expression point2) {
 		return Functions.distance(point1, point2);
 	}
 
@@ -2113,7 +1994,6 @@ public final class Cypher {
 	 * @return A function call for {@code point()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation point(MapExpression parameterMap) {
 		return Functions.point(parameterMap);
 	}
@@ -2128,7 +2008,6 @@ public final class Cypher {
 	 * @return A function call for {@code point()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation point(Expression expression) {
 		return Functions.point(expression);
 	}
@@ -2141,7 +2020,6 @@ public final class Cypher {
 	 * @return A function call for {@code point()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation point(Parameter<?> parameter) {
 		return Functions.point(parameter);
 	}
@@ -2154,7 +2032,6 @@ public final class Cypher {
 	 * @return A function call for {@code point()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation cartesian(double x, double y) {
 		return Functions.cartesian(x, y);
 	}
@@ -2167,7 +2044,6 @@ public final class Cypher {
 	 * @return A function call for {@code point()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation coordinate(double longitude, double latitude) {
 		return Functions.coordinate(longitude, latitude);
 	}
@@ -2194,7 +2070,6 @@ public final class Cypher {
 	 * @return A function call for {@code avg()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation avg(Expression expression) {
 		return Functions.avg(expression);
 	}
@@ -2207,7 +2082,6 @@ public final class Cypher {
 	 * @return A function call for {@code avg()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation avgDistinct(Expression expression) {
 		return Functions.avgDistinct(expression);
 	}
@@ -2220,8 +2094,7 @@ public final class Cypher {
 	 * @see #collect(Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation collect(@NotNull Named variable) {
+	public static FunctionInvocation collect(Named variable) {
 		return Functions.collect(variable);
 	}
 
@@ -2233,8 +2106,7 @@ public final class Cypher {
 	 * @see #collect(Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation collectDistinct(@NotNull Named variable) {
+	public static FunctionInvocation collectDistinct(Named variable) {
 		return Functions.collectDistinct(variable);
 	}
 
@@ -2246,7 +2118,6 @@ public final class Cypher {
 	 * @return A function call for {@code collect()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation collect(Expression expression) {
 		return Functions.collect(expression);
 	}
@@ -2259,7 +2130,6 @@ public final class Cypher {
 	 * @return A function call for {@code collect()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation collectDistinct(Expression expression) {
 		return Functions.collectDistinct(expression);
 	}
@@ -2272,7 +2142,6 @@ public final class Cypher {
 	 * @return A function call for {@code max()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation max(Expression expression) {
 		return Functions.max(expression);
 	}
@@ -2285,7 +2154,6 @@ public final class Cypher {
 	 * @return A function call for {@code max()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation maxDistinct(Expression expression) {
 		return Functions.maxDistinct(expression);
 	}
@@ -2298,7 +2166,6 @@ public final class Cypher {
 	 * @return A function call for {@code min()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation min(Expression expression) {
 		return Functions.min(expression);
 	}
@@ -2311,7 +2178,6 @@ public final class Cypher {
 	 * @return A function call for {@code min()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation minDistinct(Expression expression) {
 		return Functions.minDistinct(expression);
 	}
@@ -2325,7 +2191,6 @@ public final class Cypher {
 	 * @return A function call for {@code percentileCont()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation percentileCont(Expression expression,
 		Number percentile) {
 		return Functions.percentileCont(expression, percentile);
@@ -2340,7 +2205,6 @@ public final class Cypher {
 	 * @return A function call for {@code percentileCont()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation percentileContDistinct(Expression expression,
 		Number percentile) {
 		return Functions.percentileContDistinct(expression, percentile);
@@ -2355,7 +2219,6 @@ public final class Cypher {
 	 * @return A function call for {@code percentileDisc()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation percentileDisc(Expression expression,
 		Number percentile) {
 		return Functions.percentileDisc(expression, percentile);
@@ -2370,7 +2233,6 @@ public final class Cypher {
 	 * @return A function call for {@code percentileDisc()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation percentileDiscDistinct(Expression expression,
 		Number percentile) {
 		return Functions.percentileDiscDistinct(expression, percentile);
@@ -2384,7 +2246,6 @@ public final class Cypher {
 	 * @return A function call for {@code stDev()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation stDev(Expression expression) {
 		return Functions.stDev(expression);
 	}
@@ -2397,7 +2258,6 @@ public final class Cypher {
 	 * @return A function call for {@code stDev()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation stDevDistinct(Expression expression) {
 		return Functions.stDevDistinct(expression);
 	}
@@ -2410,7 +2270,6 @@ public final class Cypher {
 	 * @return A function call for {@code stDevP()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation stDevP(Expression expression) {
 		return Functions.stDevP(expression);
 	}
@@ -2423,7 +2282,6 @@ public final class Cypher {
 	 * @return A function call for {@code stDevP()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation stDevPDistinct(Expression expression) {
 		return Functions.stDevPDistinct(expression);
 	}
@@ -2436,7 +2294,6 @@ public final class Cypher {
 	 * @return A function call for {@code sum()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation sum(Expression expression) {
 		return Functions.sum(expression);
 	}
@@ -2449,7 +2306,6 @@ public final class Cypher {
 	 * @return A function call for {@code sum()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation sumDistinct(Expression expression) {
 		return Functions.sumDistinct(expression);
 	}
@@ -2461,7 +2317,6 @@ public final class Cypher {
 	 * @see #range(Expression, Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation range(Integer start, Integer end) {
 		return Functions.range(start, end);
 	}
@@ -2473,9 +2328,8 @@ public final class Cypher {
 	 * @see #range(Expression, Expression, Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation range(@NotNull Expression start,
-		@NotNull Expression end) {
+	public static FunctionInvocation range(Expression start,
+		Expression end) {
 		return Functions.range(start, end);
 	}
 
@@ -2490,8 +2344,7 @@ public final class Cypher {
 	 * @see #range(Expression, Expression, Expression)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation range(@NotNull Integer start, @NotNull Integer end,
+	public static FunctionInvocation range(Integer start, Integer end,
 		Integer step) {
 		return Functions.range(start, end, step);
 	}
@@ -2506,9 +2359,8 @@ public final class Cypher {
 	 * @return A function call for {@code range()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation range(@NotNull Expression start,
-		@NotNull Expression end, Expression step) {
+	public static FunctionInvocation range(Expression start,
+		Expression end, Expression step) {
 		return Functions.range(start, end, step);
 	}
 
@@ -2520,7 +2372,6 @@ public final class Cypher {
 	 * @return A function call for {@code head()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation head(Expression expression) {
 		return Functions.head(expression);
 	}
@@ -2533,7 +2384,6 @@ public final class Cypher {
 	 * @return A function call for {@code last()}
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation last(Expression expression) {
 		return Functions.last(expression);
 	}
@@ -2546,8 +2396,7 @@ public final class Cypher {
 	 * @return A function call for {@code nodes()} on a path.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation nodes(@NotNull NamedPath path) {
+	public static FunctionInvocation nodes(NamedPath path) {
 		return Functions.nodes(path);
 	}
 
@@ -2559,8 +2408,7 @@ public final class Cypher {
 	 * @return A function call for {@code nodes{}} on a path represented by a symbolic name.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation nodes(@NotNull SymbolicName symbolicName) {
+	public static FunctionInvocation nodes(SymbolicName symbolicName) {
 		return Functions.nodes(symbolicName);
 	}
 
@@ -2572,8 +2420,7 @@ public final class Cypher {
 	 * @return A function call for {@code relationships()} on a path.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation relationships(@NotNull NamedPath path) {
+	public static FunctionInvocation relationships(NamedPath path) {
 		return Functions.relationships(path);
 	}
 
@@ -2585,8 +2432,7 @@ public final class Cypher {
 	 * @return A function call for {@code relationships()} on a path represented by a symbolic name.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation relationships(@NotNull SymbolicName symbolicName) {
+	public static FunctionInvocation relationships(SymbolicName symbolicName) {
 		return Functions.relationships(symbolicName);
 	}
 
@@ -2598,8 +2444,7 @@ public final class Cypher {
 	 * @return A function call for {@code startNode()} on a path.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation startNode(@NotNull Relationship relationship) {
+	public static FunctionInvocation startNode(Relationship relationship) {
 		return Functions.startNode(relationship);
 	}
 
@@ -2611,8 +2456,7 @@ public final class Cypher {
 	 * @return A function call for {@code endNode()} on a path.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation endNode(@NotNull Relationship relationship) {
+	public static FunctionInvocation endNode(Relationship relationship) {
 		return Functions.endNode(relationship);
 	}
 
@@ -2624,7 +2468,6 @@ public final class Cypher {
 	 * @return A function call for {@code date()}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation date() {
 		return Functions.date();
 	}
@@ -2639,7 +2482,6 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation calendarDate(Integer year, Integer month,
 		Integer day) {
 		return Functions.calendarDate(year, month, day);
@@ -2655,7 +2497,6 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation weekDate(Integer year, Integer week,
 		Integer dayOfWeek) {
 		return Functions.weekDate(year, week, dayOfWeek);
@@ -2671,7 +2512,6 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation quarterDate(Integer year, Integer quarter,
 		Integer dayOfQuarter) {
 		return Functions.quarterDate(year, quarter, dayOfQuarter);
@@ -2686,7 +2526,6 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation ordinalDate(Integer year, Integer ordinalDay) {
 		return Functions.ordinalDate(year, ordinalDay);
 	}
@@ -2700,8 +2539,7 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation date(@NotNull MapExpression components) {
+	public static FunctionInvocation date(MapExpression components) {
 		return Functions.date(components);
 	}
 
@@ -2714,8 +2552,7 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation date(@NotNull String temporalValue) {
+	public static FunctionInvocation date(String temporalValue) {
 		return Functions.date(temporalValue);
 	}
 
@@ -2728,8 +2565,7 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation date(@NotNull Expression temporalValue) {
+	public static FunctionInvocation date(Expression temporalValue) {
 		return Functions.date(temporalValue);
 	}
 
@@ -2740,7 +2576,6 @@ public final class Cypher {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation datetime() {
 		return Functions.datetime();
 	}
@@ -2753,8 +2588,7 @@ public final class Cypher {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation datetime(@NotNull TimeZone timeZone) {
+	public static FunctionInvocation datetime(TimeZone timeZone) {
 		return Functions.datetime(timeZone);
 	}
 
@@ -2767,8 +2601,7 @@ public final class Cypher {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation datetime(@NotNull MapExpression components) {
+	public static FunctionInvocation datetime(MapExpression components) {
 		return Functions.datetime(components);
 	}
 
@@ -2781,8 +2614,7 @@ public final class Cypher {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation datetime(@NotNull String temporalValue) {
+	public static FunctionInvocation datetime(String temporalValue) {
 		return Functions.datetime(temporalValue);
 	}
 
@@ -2795,8 +2627,7 @@ public final class Cypher {
 	 * @return A function call for {@code date({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation datetime(@NotNull Expression temporalValue) {
+	public static FunctionInvocation datetime(Expression temporalValue) {
 		return Functions.datetime(temporalValue);
 	}
 
@@ -2807,7 +2638,6 @@ public final class Cypher {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation localdatetime() {
 		return Functions.localdatetime();
 	}
@@ -2820,8 +2650,7 @@ public final class Cypher {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localdatetime(@NotNull TimeZone timeZone) {
+	public static FunctionInvocation localdatetime(TimeZone timeZone) {
 		return Functions.localdatetime(timeZone);
 	}
 
@@ -2834,8 +2663,7 @@ public final class Cypher {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localdatetime(@NotNull MapExpression components) {
+	public static FunctionInvocation localdatetime(MapExpression components) {
 		return Functions.localdatetime(components);
 	}
 
@@ -2848,8 +2676,7 @@ public final class Cypher {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localdatetime(@NotNull String temporalValue) {
+	public static FunctionInvocation localdatetime(String temporalValue) {
 		return Functions.localdatetime(temporalValue);
 	}
 
@@ -2862,8 +2689,7 @@ public final class Cypher {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localdatetime(@NotNull Expression temporalValue) {
+	public static FunctionInvocation localdatetime(Expression temporalValue) {
 		return Functions.localdatetime(temporalValue);
 	}
 
@@ -2874,7 +2700,6 @@ public final class Cypher {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation localtime() {
 		return Functions.localtime();
 	}
@@ -2887,8 +2712,7 @@ public final class Cypher {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localtime(@NotNull TimeZone timeZone) {
+	public static FunctionInvocation localtime(TimeZone timeZone) {
 		return Functions.localtime(timeZone);
 	}
 
@@ -2901,8 +2725,7 @@ public final class Cypher {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localtime(@NotNull MapExpression components) {
+	public static FunctionInvocation localtime(MapExpression components) {
 		return Functions.localtime(components);
 	}
 
@@ -2915,8 +2738,7 @@ public final class Cypher {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localtime(@NotNull String temporalValue) {
+	public static FunctionInvocation localtime(String temporalValue) {
 		return Functions.localtime(temporalValue);
 	}
 
@@ -2929,8 +2751,7 @@ public final class Cypher {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation localtime(@NotNull Expression temporalValue) {
+	public static FunctionInvocation localtime(Expression temporalValue) {
 		return Functions.localtime(temporalValue);
 	}
 
@@ -2941,7 +2762,6 @@ public final class Cypher {
 	 * @return A function call for {@code time({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation time() {
 		return Functions.time();
 	}
@@ -2954,8 +2774,7 @@ public final class Cypher {
 	 * @return A function call for {@code time({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation time(@NotNull TimeZone timeZone) {
+	public static FunctionInvocation time(TimeZone timeZone) {
 		return Functions.time(timeZone);
 	}
 
@@ -2968,8 +2787,7 @@ public final class Cypher {
 	 * @return A function call for {@code time({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation time(@NotNull MapExpression components) {
+	public static FunctionInvocation time(MapExpression components) {
 		return Functions.time(components);
 	}
 
@@ -2982,8 +2800,7 @@ public final class Cypher {
 	 * @return A function call for {@code time({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation time(@NotNull String temporalValue) {
+	public static FunctionInvocation time(String temporalValue) {
 		return Functions.time(temporalValue);
 	}
 
@@ -2996,8 +2813,7 @@ public final class Cypher {
 	 * @return A function call for {@code time({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation time(@NotNull Expression temporalValue) {
+	public static FunctionInvocation time(Expression temporalValue) {
 		return Functions.time(temporalValue);
 	}
 
@@ -3010,8 +2826,7 @@ public final class Cypher {
 	 * @return A function call for {@code duration({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation duration(@NotNull MapExpression components) {
+	public static FunctionInvocation duration(MapExpression components) {
 		return Functions.duration(components);
 	}
 
@@ -3024,8 +2839,7 @@ public final class Cypher {
 	 * @return A function call for {@code duration({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation duration(@NotNull String temporalAmount) {
+	public static FunctionInvocation duration(String temporalAmount) {
 		return Functions.duration(temporalAmount);
 	}
 
@@ -3038,8 +2852,7 @@ public final class Cypher {
 	 * @return A function call for {@code duration({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation duration(@NotNull Expression temporalAmount) {
+	public static FunctionInvocation duration(Expression temporalAmount) {
 		return Functions.duration(temporalAmount);
 	}
 
@@ -3050,9 +2863,8 @@ public final class Cypher {
 	 * @return An ongoing definition for a function call to {@code reduce({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static Reduction.OngoingDefinitionWithVariable reduce(
-		@NotNull SymbolicName variable) {
+		SymbolicName variable) {
 		return Functions.reduce(variable);
 	}
 
@@ -3064,8 +2876,7 @@ public final class Cypher {
 	 * @return A function call for {@code abs({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation abs(@NotNull Expression expression) {
+	public static FunctionInvocation abs(Expression expression) {
 		return Functions.abs(expression);
 	}
 
@@ -3077,8 +2888,7 @@ public final class Cypher {
 	 * @return A function call for {@code ceil({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation ceil(@NotNull Expression expression) {
+	public static FunctionInvocation ceil(Expression expression) {
 		return Functions.ceil(expression);
 	}
 
@@ -3090,8 +2900,7 @@ public final class Cypher {
 	 * @return A function call for {@code floor({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation floor(@NotNull Expression expression) {
+	public static FunctionInvocation floor(Expression expression) {
 		return Functions.floor(expression);
 	}
 
@@ -3102,7 +2911,6 @@ public final class Cypher {
 	 * @return A function call for {@code rand({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation rand() {
 		return Functions.rand();
 	}
@@ -3117,7 +2925,6 @@ public final class Cypher {
 	 * @return A function call for {@code round({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation round(Expression value, Expression... expression) {
 		return Functions.round(value, expression);
 	}
@@ -3130,8 +2937,7 @@ public final class Cypher {
 	 * @return A function call for {@code sign({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation sign(@NotNull Expression expression) {
+	public static FunctionInvocation sign(Expression expression) {
 		return Functions.sign(expression);
 	}
 
@@ -3142,7 +2948,6 @@ public final class Cypher {
 	 * @return A function call for {@code e({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation e() {
 		return Functions.e();
 	}
@@ -3155,8 +2960,7 @@ public final class Cypher {
 	 * @return A function call for {@code exp({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation exp(@NotNull Expression expression) {
+	public static FunctionInvocation exp(Expression expression) {
 		return Functions.exp(expression);
 	}
 
@@ -3168,8 +2972,7 @@ public final class Cypher {
 	 * @return A function call for {@code log({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation log(@NotNull Expression expression) {
+	public static FunctionInvocation log(Expression expression) {
 		return Functions.log(expression);
 	}
 
@@ -3181,8 +2984,7 @@ public final class Cypher {
 	 * @return A function call for {@code log10({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation log10(@NotNull Expression expression) {
+	public static FunctionInvocation log10(Expression expression) {
 		return Functions.log10(expression);
 	}
 
@@ -3194,8 +2996,7 @@ public final class Cypher {
 	 * @return A function call for {@code sqrt({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation sqrt(@NotNull Expression expression) {
+	public static FunctionInvocation sqrt(Expression expression) {
 		return Functions.sqrt(expression);
 	}
 
@@ -3207,8 +3008,7 @@ public final class Cypher {
 	 * @return A function call for {@code acos({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation acos(@NotNull Expression expression) {
+	public static FunctionInvocation acos(Expression expression) {
 		return Functions.acos(expression);
 	}
 
@@ -3220,8 +3020,7 @@ public final class Cypher {
 	 * @return A function call for {@code asin({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation asin(@NotNull Expression expression) {
+	public static FunctionInvocation asin(Expression expression) {
 		return Functions.asin(expression);
 	}
 
@@ -3233,8 +3032,7 @@ public final class Cypher {
 	 * @return A function call for {@code atan({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation atan(@NotNull Expression expression) {
+	public static FunctionInvocation atan(Expression expression) {
 		return Functions.atan(expression);
 	}
 
@@ -3247,9 +3045,8 @@ public final class Cypher {
 	 * @return A function call for {@code atan2({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation atan2(@NotNull Expression y,
-		@NotNull Expression x) {
+	public static FunctionInvocation atan2(Expression y,
+		Expression x) {
 		return Functions.atan2(y, x);
 	}
 
@@ -3261,8 +3058,7 @@ public final class Cypher {
 	 * @return A function call for {@code cos({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation cos(@NotNull Expression expression) {
+	public static FunctionInvocation cos(Expression expression) {
 		return Functions.cos(expression);
 	}
 
@@ -3274,8 +3070,7 @@ public final class Cypher {
 	 * @return A function call for {@code cot({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation cot(@NotNull Expression expression) {
+	public static FunctionInvocation cot(Expression expression) {
 		return Functions.cot(expression);
 	}
 
@@ -3287,8 +3082,7 @@ public final class Cypher {
 	 * @return A function call for {@code degrees({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation degrees(@NotNull Expression expression) {
+	public static FunctionInvocation degrees(Expression expression) {
 		return Functions.degrees(expression);
 	}
 
@@ -3300,8 +3094,7 @@ public final class Cypher {
 	 * @return A function call for {@code haversin({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation haversin(@NotNull Expression expression) {
+	public static FunctionInvocation haversin(Expression expression) {
 		return Functions.haversin(expression);
 	}
 
@@ -3312,7 +3105,6 @@ public final class Cypher {
 	 * @return A function call for {@code pi({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation pi() {
 		return Functions.pi();
 	}
@@ -3325,8 +3117,7 @@ public final class Cypher {
 	 * @return A function call for {@code radians({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation radians(@NotNull Expression expression) {
+	public static FunctionInvocation radians(Expression expression) {
 		return Functions.radians(expression);
 	}
 
@@ -3338,8 +3129,7 @@ public final class Cypher {
 	 * @return A function call for {@code sin({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation sin(@NotNull Expression expression) {
+	public static FunctionInvocation sin(Expression expression) {
 		return Functions.sin(expression);
 	}
 
@@ -3351,8 +3141,7 @@ public final class Cypher {
 	 * @return A function call for {@code tan({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation tan(@NotNull Expression expression) {
+	public static FunctionInvocation tan(Expression expression) {
 		return Functions.tan(expression);
 	}
 
@@ -3364,8 +3153,7 @@ public final class Cypher {
 	 * @return A function call for {@code toInteger({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toInteger(@NotNull Expression expression) {
+	public static FunctionInvocation toInteger(Expression expression) {
 		return Functions.toInteger(expression);
 	}
 
@@ -3377,8 +3165,7 @@ public final class Cypher {
 	 * @return A function call for {@code toString({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toString(@NotNull Expression expression) {
+	public static FunctionInvocation toString(Expression expression) {
 		return Functions.toString(expression);
 	}
 
@@ -3390,8 +3177,7 @@ public final class Cypher {
 	 * @return A function call for {@code toStringOrNull({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toStringOrNull(@NotNull Expression expression) {
+	public static FunctionInvocation toStringOrNull(Expression expression) {
 		return Functions.toStringOrNull(expression);
 	}
 
@@ -3403,8 +3189,7 @@ public final class Cypher {
 	 * @return A function call for {@code toFloat({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toFloat(@NotNull Expression expression) {
+	public static FunctionInvocation toFloat(Expression expression) {
 		return Functions.toFloat(expression);
 	}
 
@@ -3416,8 +3201,7 @@ public final class Cypher {
 	 * @return A function call for {@code toBoolean({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation toBoolean(@NotNull Expression expression) {
+	public static FunctionInvocation toBoolean(Expression expression) {
 		return Functions.toBoolean(expression);
 	}
 
@@ -3427,7 +3211,6 @@ public final class Cypher {
 	 * @return A function call for {@code linenumber({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation linenumber() {
 		return Functions.linenumber();
 	}
@@ -3438,7 +3221,6 @@ public final class Cypher {
 	 * @return A function call for {@code file({})}.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static FunctionInvocation file() {
 		return Functions.file();
 	}
@@ -3461,8 +3243,7 @@ public final class Cypher {
 	 * @return A function call for {@code length()} on a path.
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
-	public static FunctionInvocation length(@NotNull NamedPath path) {
+	public static FunctionInvocation length(NamedPath path) {
 		return Functions.length(path);
 	}
 
@@ -3473,8 +3254,7 @@ public final class Cypher {
 	 * @return A function call for {@code graph.names()}.
 	 * @since 2023.9.0
 	 */
-	@Neo4jVersion(minimum = "5.0.0") @Contract(pure = true) @NotNull
-	public static FunctionInvocation graphNames() {
+	@Neo4jVersion(minimum = "5.0.0") public static FunctionInvocation graphNames() {
 		return Functions.graphNames();
 	}
 
@@ -3486,8 +3266,7 @@ public final class Cypher {
 	 * @return A function call for {@code graph.propertiesByName()}.
 	 * @since 2023.9.0
 	 */
-	@Neo4jVersion(minimum = "5.0.0") @Contract(pure = true) @NotNull
-	public static FunctionInvocation graphPropertiesByName(Expression name) {
+	@Neo4jVersion(minimum = "5.0.0") public static FunctionInvocation graphPropertiesByName(Expression name) {
 		return Functions.graphPropertiesByName(name);
 	}
 
@@ -3499,8 +3278,7 @@ public final class Cypher {
 	 * @return A function call for {@code graph.byName()}.
 	 * @since 2023.9.0
 	 */
-	@Neo4jVersion(minimum = "5.0.0") @Contract(pure = true) @NotNull
-	public static FunctionInvocation graphByName(
+	@Neo4jVersion(minimum = "5.0.0") public static FunctionInvocation graphByName(
 		Expression name) {
 		return Functions.graphByName(name);
 	}
@@ -3640,7 +3418,6 @@ public final class Cypher {
 	 * @return A function call for {@code exists()} for one property
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static Condition exists(Property property) {
 		return Predicates.exists(property);
 	}
@@ -3653,7 +3430,6 @@ public final class Cypher {
 	 * @return A function call for {@code exists()} for one pattern
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static Condition exists(RelationshipPattern pattern) {
 		return Predicates.exists(pattern);
 	}
@@ -3710,7 +3486,7 @@ public final class Cypher {
 	 * @return An existential sub-query.
 	 * @since 2023.9.0
 	 */
-	public static Condition exists(List<PatternElement> pattern, @Nullable Where where) {
+	public static Condition exists(List<PatternElement> pattern, Where where) {
 		return Predicates.exists(pattern, where);
 	}
 
@@ -3720,7 +3496,6 @@ public final class Cypher {
 	 * @see #all(SymbolicName)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction all(String variable) {
 		return Predicates.all(variable);
 	}
@@ -3733,7 +3508,6 @@ public final class Cypher {
 	 * @return A builder for the {@code all()} predicate function
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction all(
 		SymbolicName variable) {
 		return Predicates.all(variable);
@@ -3745,7 +3519,6 @@ public final class Cypher {
 	 * @see #any(SymbolicName)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction any(String variable) {
 		return Predicates.any(variable);
 	}
@@ -3758,7 +3531,6 @@ public final class Cypher {
 	 * @return A builder for the {@code any()} predicate function
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction any(
 		SymbolicName variable) {
 		return Predicates.any(variable);
@@ -3770,7 +3542,6 @@ public final class Cypher {
 	 * @see #none(SymbolicName)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction none(String variable) {
 		return Predicates.none(variable);
 	}
@@ -3783,7 +3554,6 @@ public final class Cypher {
 	 * @return A builder for the {@code none()} predicate function
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction none(
 		SymbolicName variable) {
 		return Predicates.none(variable);
@@ -3795,7 +3565,6 @@ public final class Cypher {
 	 * @see #single(SymbolicName)
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction single(String variable) {
 		return Predicates.single(variable);
 	}
@@ -3808,7 +3577,6 @@ public final class Cypher {
 	 * @return A builder for the {@code single()} predicate function
 	 * @since 2023.9.0
 	 */
-	@Contract(pure = true) @NotNull
 	public static OngoingListBasedPredicateFunction single(
 		SymbolicName variable) {
 		return Predicates.single(variable);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultLoadCSVStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultLoadCSVStatementBuilder.java
@@ -23,9 +23,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.net.URI;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.internal.LoadCSV;
 import org.neo4j.cypherdsl.core.internal.UsingPeriodicCommit;
 
@@ -57,7 +54,7 @@ final class DefaultLoadCSVStatementBuilder extends DefaultStatementBuilder imple
 			this(uri, withHeaders, null);
 		}
 
-		PrepareLoadCSVStatementImpl(URI uri, boolean withHeaders, @Nullable DefaultStatementBuilder source) {
+		PrepareLoadCSVStatementImpl(URI uri, boolean withHeaders, DefaultStatementBuilder source) {
 
 			this.usingPeriodicCommit = null;
 
@@ -66,15 +63,13 @@ final class DefaultLoadCSVStatementBuilder extends DefaultStatementBuilder imple
 			this.source = source;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public LoadCSVStatementBuilder as(String alias) {
 
 			return DefaultLoadCSVStatementBuilder.create(this, alias, source);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingLoadCSV loadCSV(URI newUri, boolean newWithHeaders) {
 
 			this.uri = newUri;
@@ -84,7 +79,7 @@ final class DefaultLoadCSVStatementBuilder extends DefaultStatementBuilder imple
 	}
 
 	static DefaultLoadCSVStatementBuilder create(PrepareLoadCSVStatementImpl config, String alias,
-		@Nullable DefaultStatementBuilder source) {
+		DefaultStatementBuilder source) {
 
 		// It should be reasonable safe to keep that immutable object around
 		final LoadCSV loadCSV = new LoadCSV(config.uri, config.withHeaders, alias);
@@ -111,7 +106,6 @@ final class DefaultLoadCSVStatementBuilder extends DefaultStatementBuilder imple
 	}
 
 	@Override
-	@NotNull @Contract(pure = true)
 	public StatementBuilder withFieldTerminator(String fieldTerminator) {
 		return new DefaultStatementBuilder(this.usingPeriodicCommit, this.loadCSV.withFieldTerminator(fieldTerminator));
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -32,7 +32,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.StatementBuilder.BuildableMatchAndUpdate;
 import org.neo4j.cypherdsl.core.StatementBuilder.BuildableOngoingMergeAction;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingMatchAndUpdate;
@@ -110,7 +109,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithoutWhere match(boolean optional, PatternElement... pattern) {
 
@@ -124,34 +122,29 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingUpdate create(PatternElement... pattern) {
 
 		return update(UpdateType.CREATE, pattern);
 	}
 
-	@NotNull
 	@Override
 	public final OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 
 		return create(pattern.toArray(new PatternElement[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final OngoingMerge merge(PatternElement... pattern) {
 
 		return update(UpdateType.MERGE, pattern);
 	}
 
-	@NotNull
 	@Override
 	public final OngoingMergeAction onCreate() {
 		return ongoingOnAfterMerge(MergeAction.Type.ON_CREATE);
 	}
 
-	@NotNull
 	@Override
 	public final OngoingMergeAction onMatch() {
 		return ongoingOnAfterMerge(MergeAction.Type.ON_MATCH);
@@ -165,27 +158,25 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return new OngoingMergeAction() {
 
 			@Override
-			public @NotNull BuildableOngoingMergeAction set(Node node, String... labels) {
+			public BuildableOngoingMergeAction set(Node node, String... labels) {
 
 				return this.set(Operations.set(node, labels));
 			}
 
 			@Override
-			public @NotNull BuildableOngoingMergeAction set(Node node, Collection<String> labels) {
+			public BuildableOngoingMergeAction set(Node node, Collection<String> labels) {
 
 				return this.set(Operations.set(node, labels.toArray(new String[0])));
 			}
 
-			@NotNull
-			@Override
+					@Override
 			public BuildableOngoingMergeAction mutate(Expression target, Expression properties) {
 				((SupportsActionsOnTheUpdatingClause) DefaultStatementBuilder.this.currentOngoingUpdate.builder)
 					.on(type, UpdateType.MUTATE, target, properties);
 				return DefaultStatementBuilder.this;
 			}
 
-			@NotNull
-			@Override
+					@Override
 			public BuildableOngoingMergeAction set(Expression... expressions) {
 
 				((SupportsActionsOnTheUpdatingClause) DefaultStatementBuilder.this.currentOngoingUpdate.builder)
@@ -193,8 +184,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				return DefaultStatementBuilder.this;
 			}
 
-			@NotNull
-			@Override
+					@Override
 			public BuildableOngoingMergeAction set(Collection<? extends Expression> expressions) {
 				return set(expressions.toArray(new Expression[] {}));
 			}
@@ -226,21 +216,18 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingAndReturn returning(Collection<? extends Expression> elements) {
 
 		return returning(false, false, elements);
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> elements) {
 
 		return returning(false, true, elements);
 	}
 
-	@NotNull
 	@Override
 	public StatementBuilder.OngoingReadingAndReturn returningRaw(Expression rawExpression) {
 
@@ -254,13 +241,11 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return ongoingMatchAndReturn;
 	}
 
-	@NotNull
 	@Override
 	public final OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements) {
 		return with(false, elements);
 	}
 
-	@NotNull
 	@Override
 	public OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> elements) {
 		return with(true, elements);
@@ -273,35 +258,30 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return ongoingMatchAndWith;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingUpdate delete(Expression... expressions) {
 
 		return update(UpdateType.DELETE, expressions);
 	}
 
-	@NotNull
 	@Override
 	public final OngoingUpdate delete(Collection<? extends Expression> expressions) {
 
 		return delete(expressions.toArray(new Expression[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final OngoingUpdate detachDelete(Expression... expressions) {
 
 		return update(UpdateType.DETACH_DELETE, expressions);
 	}
 
-	@NotNull
 	@Override
 	public final OngoingUpdate detachDelete(Collection<? extends Expression> expressions) {
 
 		return detachDelete(expressions.toArray(new Expression[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate set(Expression... expressions) {
 
@@ -310,14 +290,12 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return result;
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate set(Collection<? extends Expression> expressions) {
 
 		return set(expressions.toArray(new Expression[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate set(Node named, String... labels) {
 
@@ -325,14 +303,12 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return new DefaultStatementWithUpdateBuilder(UpdateType.SET, Operations.set(named, labels));
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate set(Node named, Collection<String> labels) {
 
 		return set(named, labels.toArray(new String[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate mutate(Expression target, Expression properties) {
 
@@ -341,7 +317,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return result;
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate remove(Property... properties) {
 
@@ -349,14 +324,12 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, properties);
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate remove(Collection<Property> properties) {
 
 		return remove(properties.toArray(new Property[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate remove(Node named, String... labels) {
 
@@ -364,14 +337,12 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, Operations.remove(named, labels));
 	}
 
-	@NotNull
 	@Override
 	public final BuildableMatchAndUpdate remove(Node named, Collection<String> labels) {
 
 		return remove(named, labels.toArray(new String[] {}));
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithWhere where(Condition newCondition) {
 
@@ -387,7 +358,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithWhere and(Condition additionalCondition) {
 
@@ -395,7 +365,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithWhere or(Condition additionalCondition) {
 
@@ -403,7 +372,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public Statement build() {
 
@@ -457,7 +425,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		this.currentSinglePartElements.add(updatingClause);
 	}
 
-	@NotNull
 	@Override
 	public BuildableSubquery call(Statement statement, IdentifiableElement... imports) {
 
@@ -469,7 +436,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public BuildableSubquery callRawCypher(String rawCypher, Object... args) {
 
@@ -481,7 +447,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public BuildableSubquery callInTransactions(Statement statement, Integer rows, IdentifiableElement... imports) {
 
@@ -511,7 +476,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		this.currentOngoingUpdate = null;
 	}
 
-	@NotNull
 	@Override
 	public final Condition asCondition() {
 
@@ -522,7 +486,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return ExistentialSubquery.exists(this.currentOngoingMatch.buildMatch());
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithoutWhere usingIndex(Property... properties) {
 
@@ -530,7 +493,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithoutWhere usingIndexSeek(Property... properties) {
 
@@ -538,7 +500,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithoutWhere usingScan(Node node) {
 
@@ -546,7 +507,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return this;
 	}
 
-	@NotNull
 	@Override
 	public final OngoingReadingWithoutWhere usingJoinOn(SymbolicName... names) {
 
@@ -555,7 +515,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 	}
 
 	@Override
-	public @NotNull ForeachSourceStep foreach(SymbolicName variable) {
+	public ForeachSourceStep foreach(SymbolicName variable) {
 
 		this.closeCurrentOngoingMatch();
 		this.closeCurrentOngoingUpdate();
@@ -564,7 +524,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 	}
 
 	@Override
-	public @NotNull Terminal finish() {
+	public Terminal finish() {
 		return new DefaultStatementWithFinishBuilder();
 	}
 
@@ -579,7 +539,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public ForeachUpdateStep in(@NotNull Expression newVariableList) {
+		public ForeachUpdateStep in(Expression newVariableList) {
 
 			this.list = Objects.requireNonNull(newVariableList);
 			return this;
@@ -640,75 +600,64 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return extractIdentifiablesFromReturnList(returnList);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final OngoingMatchAndReturnWithOrder orderBy(SortItem... sortItem) {
 			orderBuilder.orderBy(sortItem);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final OngoingMatchAndReturnWithOrder orderBy(Collection<SortItem> sortItem) {
 			return orderBy(sortItem.toArray(new SortItem[] {}));
 		}
 
-		@NotNull
-		@Override
-		public final TerminalOngoingOrderDefinition orderBy(@NotNull Expression expression) {
+			@Override
+		public final TerminalOngoingOrderDefinition orderBy(Expression expression) {
 			orderBuilder.orderBy(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
-		public final TerminalOngoingOrderDefinition and(@NotNull Expression expression) {
+			@Override
+		public final TerminalOngoingOrderDefinition and(Expression expression) {
 			orderBuilder.and(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final DefaultStatementWithReturnBuilder descending() {
 			orderBuilder.descending();
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final DefaultStatementWithReturnBuilder ascending() {
 			orderBuilder.ascending();
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final OngoingReadingAndReturn skip(Number number) {
 			return skip(number == null ? null : new NumberLiteral(number));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final OngoingReadingAndReturn skip(Expression expression) {
 			orderBuilder.skip(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final OngoingReadingAndReturn limit(Number number) {
 			return limit(number == null ? null : new NumberLiteral(number));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public final OngoingReadingAndReturn limit(Expression expression) {
 			orderBuilder.limit(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public ResultStatement build() {
 
 			Return returning = Return.create(rawReturn, distinct, returnList, orderBuilder);
@@ -719,7 +668,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 	protected final class DefaultStatementWithFinishBuilder implements Terminal {
 
 		@Override
-		public @NotNull Statement build() {
+		public Statement build() {
 			return (ResultStatement) DefaultStatementBuilder.this.buildImpl(Finish.create());
 		}
 	}
@@ -762,8 +711,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return extractIdentifiablesFromReturnList(returnList);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			return DefaultStatementBuilder.this
@@ -771,8 +719,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.returning(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions) {
 
 			return DefaultStatementBuilder.this
@@ -780,16 +727,14 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.returningDistinct(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returningRaw(Expression rawExpression) {
 			return DefaultStatementBuilder.this
 				.addWith(buildWith())
 				.returningRaw(rawExpression);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate delete(Expression... expressions) {
 
 			return DefaultStatementBuilder.this
@@ -797,15 +742,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.delete(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate delete(Collection<? extends Expression> expressions) {
 
 			return delete(expressions.toArray(new Expression[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate detachDelete(Expression... expressions) {
 
 			return DefaultStatementBuilder.this
@@ -813,15 +756,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.detachDelete(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate detachDelete(Collection<? extends Expression> expressions) {
 
 			return detachDelete(expressions.toArray(new Expression[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Expression... expressions) {
 
 			return DefaultStatementBuilder.this
@@ -829,15 +770,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.set(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Collection<? extends Expression> expressions) {
 
 			return set(expressions.toArray(new Expression[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Node node, String... labels) {
 
 			return DefaultStatementBuilder.this
@@ -845,15 +784,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.set(node, labels);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Node node, Collection<String> labels) {
 
 			return set(node, labels.toArray(new String[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate mutate(Expression target, Expression properties) {
 
 			return DefaultStatementBuilder.this
@@ -861,8 +798,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.mutate(target, properties);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Node node, String... labels) {
 
 			return DefaultStatementBuilder.this
@@ -870,15 +806,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.remove(node, labels);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Node node, Collection<String> labels) {
 
 			return remove(node, labels.toArray(new String[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Property... properties) {
 
 			return DefaultStatementBuilder.this
@@ -886,15 +820,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.remove(properties);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Collection<Property> properties) {
 
 			return remove(properties.toArray(new Property[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements) {
 
 			return DefaultStatementBuilder.this
@@ -902,8 +834,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.with(elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> elements) {
 
 			return DefaultStatementBuilder.this
@@ -911,32 +842,28 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.withDistinct(elements);
 		}
 
-		@NotNull
-		@Override
-		public OrderableOngoingReadingAndWithWithWhere where(@NotNull Condition newCondition) {
+			@Override
+		public OrderableOngoingReadingAndWithWithWhere where(Condition newCondition) {
 
 			conditionBuilder.where(newCondition);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithWhere and(Condition additionalCondition) {
 
 			conditionBuilder.and(additionalCondition);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithWhere or(Condition additionalCondition) {
 
 			conditionBuilder.or(additionalCondition);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingWithoutWhere match(boolean optional, PatternElement... pattern) {
 
 			return DefaultStatementBuilder.this
@@ -944,8 +871,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.match(optional, pattern);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate create(PatternElement... pattern) {
 
 			return DefaultStatementBuilder.this
@@ -953,15 +879,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.create(pattern);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 
 			return create(pattern.toArray(new PatternElement[]{}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingMerge merge(PatternElement... pattern) {
 
 			return DefaultStatementBuilder.this
@@ -977,8 +901,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.unwind(expression);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableSubquery call(Statement statement, IdentifiableElement... imports) {
 
 			return DefaultStatementBuilder.this
@@ -987,23 +910,21 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public @NotNull BuildableSubquery callRawCypher(String rawCypher, Object... args) {
+		public BuildableSubquery callRawCypher(String rawCypher, Object... args) {
 
 			return DefaultStatementBuilder.this
 				.addWith(buildWith())
 				.callRawCypher(rawCypher, args);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableSubquery callInTransactions(Statement statement, Integer rows, IdentifiableElement... imports) {
 			return DefaultStatementBuilder.this
 				.addWith(buildWith())
 				.callInTransactions(statement, rows, imports);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public InQueryCallBuilder call(String... namespaceAndProcedure) {
 
 			return DefaultStatementBuilder.this
@@ -1011,83 +932,72 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.call(namespaceAndProcedure);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithWhere orderBy(SortItem... sortItem) {
 			orderBuilder.orderBy(sortItem);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithWhere orderBy(Collection<SortItem> sortItem) {
 			return orderBy(sortItem.toArray(new SortItem[] {}));
 		}
 
-		@NotNull
-		@Override
-		public OngoingOrderDefinition orderBy(@NotNull Expression expression) {
+			@Override
+		public OngoingOrderDefinition orderBy(Expression expression) {
 			orderBuilder.orderBy(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
-		public OngoingOrderDefinition and(@NotNull Expression expression) {
+			@Override
+		public OngoingOrderDefinition and(Expression expression) {
 			orderBuilder.and(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndWithWithWhereAndOrder descending() {
 			orderBuilder.descending();
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndWithWithWhereAndOrder ascending() {
 			orderBuilder.ascending();
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndWithWithSkip skip(Number number) {
 			return skip(number == null ? null : new NumberLiteral(number));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndWithWithSkip skip(Expression expression) {
 			orderBuilder.skip(expression);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndWith limit(Number number) {
 			return limit(number == null ? null : new NumberLiteral(number));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndWith limit(Expression expression) {
 			orderBuilder.limit(expression);
 			return this;
 		}
 
 		@Override
-		@NotNull
-		public LoadCSVStatementBuilder.OngoingLoadCSV loadCSV(URI from, boolean withHeaders) {
+			public LoadCSVStatementBuilder.OngoingLoadCSV loadCSV(URI from, boolean withHeaders) {
 
 			DefaultStatementBuilder this0 = DefaultStatementBuilder.this.addWith(buildWith());
 			return new DefaultLoadCSVStatementBuilder.PrepareLoadCSVStatementImpl(from, withHeaders, this0);
 		}
 
 		@Override
-		public @NotNull ForeachSourceStep foreach(SymbolicName variable) {
+		public ForeachSourceStep foreach(SymbolicName variable) {
 
 			return DefaultStatementBuilder.this
 				.addWith(buildWith())
@@ -1095,7 +1005,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public @NotNull StatementBuilder.Terminal finish() {
+		public StatementBuilder.Terminal finish() {
 			return DefaultStatementBuilder.this;
 		}
 	}
@@ -1231,7 +1141,6 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return propertyOperations;
 	}
 
-	@NotNull
 	private static Collection<Expression> extractIdentifiablesFromReturnList(List<Expression> returnList) {
 		return returnList.stream()
 			.filter(IdentifiableElement.class::isInstance)
@@ -1312,8 +1221,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			this.builder = getUpdatingClauseBuilder(updateType, expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
@@ -1323,8 +1231,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return delegate;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> elements) {
 
 			DefaultStatementWithReturnBuilder delegate = (DefaultStatementWithReturnBuilder) returning(elements);
@@ -1332,40 +1239,34 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return delegate;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returningRaw(Expression rawExpression) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
 			return new DefaultStatementWithReturnBuilder(rawExpression);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate delete(Expression... deletedExpressions) {
 			return delete(false, deletedExpressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate delete(Collection<? extends Expression> deletedExpressions) {
 			return delete(deletedExpressions.toArray(new Expression[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate detachDelete(Expression... deletedExpressions) {
 			return delete(true, deletedExpressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate detachDelete(Collection<? extends Expression> deletedExpressions) {
 			return detachDelete(deletedExpressions.toArray(new Expression[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingMerge merge(PatternElement... pattern) {
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
 			return DefaultStatementBuilder.this.merge(pattern);
@@ -1377,8 +1278,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 				.update(nextDetach ? UpdateType.DETACH_DELETE : UpdateType.DELETE, deletedExpressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Expression... keyValuePairs) {
 
 			DefaultStatementWithUpdateBuilder result = DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(UpdateType.SET, keyValuePairs);
@@ -1386,15 +1286,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return result;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Collection<? extends Expression> keyValuePairs) {
 
 			return set(keyValuePairs.toArray(new Expression[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Node node, String... labels) {
 
 			DefaultStatementWithUpdateBuilder result = DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(
@@ -1403,15 +1301,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return result;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate set(Node node, Collection<String> labels) {
 
 			return set(node, labels.toArray(new String[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate mutate(Expression target, Expression properties) {
 
 			DefaultStatementWithUpdateBuilder result = DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(
@@ -1420,8 +1316,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return result;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Node node, String... labels) {
 
 			DefaultStatementWithUpdateBuilder result = DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE,
@@ -1430,15 +1325,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return result;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Node node, Collection<String> labels) {
 
 			return remove(node, labels.toArray(new String[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Property... properties) {
 
 			DefaultStatementWithUpdateBuilder result = DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, properties);
@@ -1446,34 +1339,29 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return result;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableMatchAndUpdate remove(Collection<Property> properties) {
 
 			return remove(properties.toArray(new Property[] {}));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> returnedExpressions) {
 			return this.with(false, returnedExpressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> elements) {
 			return this.with(true, elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate create(PatternElement... pattern) {
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
 			return DefaultStatementBuilder.this.create(pattern);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 			return create(pattern.toArray(new PatternElement[] {}));
 		}
@@ -1483,8 +1371,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return DefaultStatementBuilder.this.with(distinct, elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public Statement build() {
 
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
@@ -1492,14 +1379,14 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public @NotNull ForeachSourceStep foreach(SymbolicName variable) {
+		public ForeachSourceStep foreach(SymbolicName variable) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
 			return DefaultStatementBuilder.this.foreach(variable);
 		}
 
 		@Override
-		public @NotNull StatementBuilder.Terminal finish() {
+		public StatementBuilder.Terminal finish() {
 
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
 			return new DefaultStatementWithFinishBuilder();
@@ -1535,15 +1422,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 			this.expressionToUnwind = expressionToUnwind;
 		}
 
-		@NotNull
-		@Override
-		public OngoingReading as(@NotNull String variable) {
+			@Override
+		public OngoingReading as(String variable) {
 			DefaultStatementBuilder.this.currentSinglePartElements.add(new Unwind(expressionToUnwind, variable));
 			return DefaultStatementBuilder.this;
 		}
 	}
 
-	@NotNull
 	@Override
 	public InQueryCallBuilder call(String... namespaceAndProcedure) {
 
@@ -1589,36 +1474,31 @@ class DefaultStatementBuilder implements StatementBuilder,
 			super(procedureName);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StandaloneCallBuilder withArgs(Expression... arguments) {
 
 			super.arguments = arguments;
 			return this;
 		}
 
-		@NotNull
-		public OngoingStandaloneCallWithReturnFields yield(Asterisk asterisk) {
+			public OngoingStandaloneCallWithReturnFields yield(Asterisk asterisk) {
 
 			return new YieldingStandaloneCallBuilder(procedureName, arguments, asterisk);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public DefaultStatementBuilder.YieldingStandaloneCallBuilder yield(SymbolicName... resultFields) {
 
 			return new YieldingStandaloneCallBuilder(procedureName, arguments, resultFields);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public DefaultStatementBuilder.YieldingStandaloneCallBuilder yield(AliasedExpression... aliasedResultFields) {
 
 			return new YieldingStandaloneCallBuilder(procedureName,  arguments, aliasedResultFields);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public Expression asFunction(boolean distinct) {
 
 			if (super.arguments == null || super.arguments.length == 0) {
@@ -1636,8 +1516,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return new DefaultStatementBuilder(this.build());
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public ProcedureCall build() {
 
 			return ProcedureCallImpl.create(procedureName, createArgumentList(), null,
@@ -1667,65 +1546,56 @@ class DefaultStatementBuilder implements StatementBuilder,
 			this.yieldItems = YieldItems.yieldAllOf(aliasedResultFields);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StatementBuilder.OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			return new DefaultStatementBuilder(this.buildCall()).returning(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StatementBuilder.OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions) {
 
 			return new DefaultStatementBuilder(this.buildCall()).returningDistinct(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StatementBuilder.OngoingReadingAndReturn returningRaw(Expression rawExpression) {
 			return new DefaultStatementBuilder(this.buildCall()).returningRaw(rawExpression);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StatementBuilder.OngoingReadingWithWhere where(Condition newCondition) {
 
 			conditionBuilder.where(newCondition);
 			return new DefaultStatementBuilder(this.buildCall());
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements) {
 			return new DefaultStatementBuilder(this.buildCall()).with(elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> elements) {
 			return new DefaultStatementBuilder(this.buildCall()).withDistinct(elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableSubquery call(Statement statement, IdentifiableElement... imports) {
 			return new DefaultStatementBuilder(this.buildCall()).call(statement, imports);
 		}
 
 		@Override
-		public @NotNull BuildableSubquery callRawCypher(String rawCypher, Object... args) {
+		public BuildableSubquery callRawCypher(String rawCypher, Object... args) {
 			return new DefaultStatementBuilder(this.buildCall()).callRawCypher(rawCypher, args);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableSubquery callInTransactions(Statement statement, Integer rows, IdentifiableElement... imports) {
 			return new DefaultStatementBuilder(this.buildCall()).callInTransactions(statement, rows, imports);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public Statement build() {
 
 			if (this.delegate != null) {
@@ -1740,8 +1610,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return build();
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public  StatementBuilder.OngoingReadingWithoutWhere match(boolean optional, PatternElement... pattern) {
 			return new DefaultStatementBuilder(this.buildCall()).match(optional, pattern);
 		}
@@ -1756,7 +1625,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public @NotNull StatementBuilder.Terminal finish() {
+		public StatementBuilder.Terminal finish() {
 			return new DefaultStatementBuilder(this.buildCall());
 		}
 	}
@@ -1779,32 +1648,28 @@ class DefaultStatementBuilder implements StatementBuilder,
 				conditionBuilder.buildCondition().map(Where::new).orElse(null));
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public InQueryCallBuilder withArgs(Expression... arguments) {
 
 			super.arguments = arguments;
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public InQueryCallBuilder yield(SymbolicName... resultFields) {
 
 			this.yieldItems = YieldItems.yieldAllOf(resultFields);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public InQueryCallBuilder yield(AliasedExpression... aliasedResultFields) {
 
 			this.yieldItems = YieldItems.yieldAllOf(aliasedResultFields);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingWithWhere where(Condition newCondition) {
 
 			conditionBuilder.where(newCondition);
@@ -1812,47 +1677,41 @@ class DefaultStatementBuilder implements StatementBuilder,
 			return DefaultStatementBuilder.this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.returning(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.returningDistinct(expressions);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OngoingReadingAndReturn returningRaw(Expression rawExpression) {
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.returningRaw(rawExpression);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.with(elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> elements) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.withDistinct(elements);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableSubquery call(Statement statement, IdentifiableElement... imports) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
@@ -1860,22 +1719,20 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public @NotNull BuildableSubquery callRawCypher(String rawCypher, Object... args) {
+		public BuildableSubquery callRawCypher(String rawCypher, Object... args) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.callRawCypher(rawCypher, args);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public BuildableSubquery callInTransactions(Statement statement, Integer rows, IdentifiableElement... imports) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.callInTransactions(statement, rows, imports);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public
 		StatementBuilder.OngoingReadingWithoutWhere match(boolean optional, PatternElement... pattern) {
 
@@ -1890,13 +1747,13 @@ class DefaultStatementBuilder implements StatementBuilder,
 		}
 
 		@Override
-		public @NotNull ForeachSourceStep foreach(SymbolicName variable) {
+		public ForeachSourceStep foreach(SymbolicName variable) {
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.foreach(variable);
 		}
 
 		@Override
-		public @NotNull StatementBuilder.Terminal finish() {
+		public StatementBuilder.Terminal finish() {
 			return DefaultStatementBuilder.this;
 		}
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DriverValueAdapter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DriverValueAdapter.java
@@ -33,7 +33,6 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.build.annotations.RegisterForReflection;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.types.TypeSystem;
@@ -55,7 +54,6 @@ class DriverValueAdapter implements ForeignAdapter<Value> {
 	}
 
 	@Override
-	@NotNull
 	public Condition asCondition() {
 
 		if (value.hasType(TypeSystem.getDefault().BOOLEAN())) {
@@ -66,7 +64,6 @@ class DriverValueAdapter implements ForeignAdapter<Value> {
 	}
 
 	@Override
-	@NotNull
 	public Expression asExpression() {
 
 		return asExpression0(value);
@@ -123,7 +120,6 @@ class DriverValueAdapter implements ForeignAdapter<Value> {
 	}
 
 	@Override
-	@NotNull
 	public Node asNode() {
 
 		if (!value.hasType(TypeSystem.getDefault().NODE())) {
@@ -149,7 +145,6 @@ class DriverValueAdapter implements ForeignAdapter<Value> {
 	}
 
 	@Override
-	@NotNull
 	public Relationship asRelationship() {
 
 		if (!value.hasType(TypeSystem.getDefault().RELATIONSHIP())) {
@@ -163,7 +158,6 @@ class DriverValueAdapter implements ForeignAdapter<Value> {
 	}
 
 	@Override
-	@NotNull
 	public SymbolicName asName() {
 		throw new UnsupportedOperationException();
 	}
@@ -242,8 +236,7 @@ class DriverValueAdapter implements ForeignAdapter<Value> {
 		}
 
 		@Override
-		@NotNull
-		public String asString() {
+			public String asString() {
 			return content.entrySet().stream()
 				.map(e -> e.getKey() + ": " + e.getValue())
 				.collect(Collectors.joining(", ", "point({", "})"));

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DurationLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DurationLiteral.java
@@ -20,7 +20,6 @@ package org.neo4j.cypherdsl.core;
 
 import java.time.Duration;
 
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A literal representing a duration value to be formatted in a way that Neo4j's Cypher understands it.
@@ -44,7 +43,6 @@ final class DurationLiteral extends LiteralBase<Duration> {
 	}
 
 	@Override
-	@NotNull
 	public String asString() {
 		var result = new StringBuilder();
 		result.append("duration('P");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExistentialSubquery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExistentialSubquery.java
@@ -23,7 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -49,16 +48,15 @@ public final class ExistentialSubquery implements SubqueryExpression, Condition 
 		return new ExistentialSubquery(statement, imports);
 	}
 
-	static Condition exists(List<PatternElement> patternElements, @Nullable Where innerWhere) {
+	static Condition exists(List<PatternElement> patternElements, Where innerWhere) {
 		return new ExistentialSubquery(patternElements, innerWhere);
 	}
 
 	private final ImportingWith importingWith;
 	private final List<Visitable> fragments;
-	@Nullable
 	private  final Where innerWhere;
 
-	ExistentialSubquery(List<PatternElement> fragments, @Nullable Where innerWhere) {
+	ExistentialSubquery(List<PatternElement> fragments, Where innerWhere) {
 		this.fragments = List.of(Pattern.of(fragments));
 		this.importingWith = new ImportingWith();
 		this.innerWhere = innerWhere;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Arrays;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
@@ -44,7 +42,7 @@ public interface ExposesCall<T> {
 	 * @param namespaceAndProcedure The procedure name of the procedure to call.
 	 * @return An ongoing definition of a call
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	T call(String... namespaceAndProcedure);
 
 	/**
@@ -60,7 +58,7 @@ public interface ExposesCall<T> {
 		 * @param arguments The list of new arguments, might be null or empty.
 		 * @return An ongoing standalone call on which yielded arguments might be configured.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		T withArgs(Expression... arguments);
 	}
 
@@ -75,7 +73,6 @@ public interface ExposesCall<T> {
 		/**
 		 * @return A function invocation that can be used as an expression, for example as a property or inside a condition.
 		 */
-		@NotNull @Contract(pure = true)
 		default Expression asFunction() {
 			return asFunction(false);
 		}
@@ -85,7 +82,6 @@ public interface ExposesCall<T> {
 		 * @return A distinct function invocation that can be used as an expression, for example as a property or inside a condition.
 		 * @since 2021.2.2
 		 */
-		@NotNull @Contract(pure = true)
 		Expression asFunction(boolean distinct);
 	}
 
@@ -103,7 +99,7 @@ public interface ExposesCall<T> {
 		 * @param yieldedItems The list of items to be yielded.
 		 * @return The ongoing standalone call to be configured.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default T yield(String... yieldedItems) {
 
 			SymbolicName[] names = new SymbolicName[0];
@@ -121,7 +117,7 @@ public interface ExposesCall<T> {
 		 * @return The ongoing standalone call to be configured.
 		 * @since 2020.1.4
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default T yield(Named... yieldedItems) {
 
 			SymbolicName[] names = new SymbolicName[0];
@@ -138,7 +134,7 @@ public interface ExposesCall<T> {
 		 * @param resultFields The list of result fields to be returned.
 		 * @return The ongoing standalone call to be configured.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		T yield(SymbolicName... resultFields);
 
 		/**
@@ -148,7 +144,7 @@ public interface ExposesCall<T> {
 		 * @param aliasedResultFields The list of result fields to be returned with new aliases given.
 		 * @return The ongoing standalone call to be configured.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		T yield(AliasedExpression... aliasedResultFields);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 import java.util.Collection;
@@ -40,7 +39,7 @@ public interface ExposesCreate {
 	 * @return An ongoing merge
 	 * @see Cypher#create(PatternElement...)
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingUpdate create(PatternElement... pattern);
 
 	/**
@@ -49,6 +48,6 @@ public interface ExposesCreate {
 	 * @see Cypher#create(Collection)
 	 * @since 2021.2.2
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingUpdate create(Collection<? extends PatternElement> pattern);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesFinish.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesFinish.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
@@ -32,7 +31,7 @@ import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 @API(status = STABLE, since = "2024.4.0")
 public interface ExposesFinish {
 
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.Terminal finish();
 
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesHints.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesHints.java
@@ -23,7 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Arrays;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
@@ -51,7 +50,7 @@ public interface ExposesHints {
 	 * @param properties One or properties that makes up the index. The properties must belong to the same node.
 	 * @return A statement using an INDEX hint.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingWithoutWhere usingIndex(Property... properties);
 
 	/**
@@ -66,7 +65,7 @@ public interface ExposesHints {
 	 * @param properties One or properties that makes up the index. The properties must belong to the same node.
 	 * @return A statement using an INDEX SEEK hint.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingWithoutWhere usingIndexSeek(Property... properties);
 
 	/**
@@ -80,7 +79,7 @@ public interface ExposesHints {
 	 * @param node The node that should be scanned
 	 * @return A statement using a SCAN hint.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingWithoutWhere usingScan(Node node);
 
 	/**
@@ -96,7 +95,7 @@ public interface ExposesHints {
 	 * @param nodes The nodes on which a join should be started.
 	 * @return A statement using a JOIN hint.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingWithoutWhere usingJoinOn(Node... nodes) {
 
 		Assertions.notEmpty(nodes, "At least one node is required to define a JOIN hint.");
@@ -116,6 +115,6 @@ public interface ExposesHints {
 	 * @param names The symbolic names identifying the nodes.
 	 * @return A statement using a JOIN hint.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingWithoutWhere usingJoinOn(SymbolicName... names);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLoadCSV.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLoadCSV.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.net.URI;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Exposes methods to configure a {@code LOAD CSV} clause.
@@ -41,7 +39,6 @@ public interface ExposesLoadCSV {
 	 * @param from The {@link URI} to load data from. Any uri that is resolvable by the database itself is valid.
 	 * @return An ongoing definition of a {@code LOAD CSV} clause
 	 */
-	@NotNull @Contract(pure = true)
 	default LoadCSVStatementBuilder.OngoingLoadCSV loadCSV(URI from) {
 		return loadCSV(from, false);
 	}
@@ -53,6 +50,5 @@ public interface ExposesLoadCSV {
 	 * @param withHeaders Set to {@literal true} if the csv file contains header
 	 * @return An ongoing definition of a {@code LOAD CSV} clause
 	 */
-	@NotNull @Contract(pure = true)
 	LoadCSVStatementBuilder.OngoingLoadCSV loadCSV(URI from, boolean withHeaders);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLogicalOperators.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLogicalOperators.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
@@ -39,7 +38,7 @@ public interface ExposesLogicalOperators<T> {
 	 * @param condition An additional condition
 	 * @return The ongoing definition of a match
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	T and(Condition condition);
 
 	/**
@@ -50,7 +49,7 @@ public interface ExposesLogicalOperators<T> {
 	 * @param pathPattern An additional pattern to include in the conditions
 	 * @return The ongoing definition of a match
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default T and(RelationshipPattern pathPattern) {
 		return this.and(RelationshipPatternCondition.of(pathPattern));
 	}
@@ -63,7 +62,7 @@ public interface ExposesLogicalOperators<T> {
 	 * @param condition An additional condition
 	 * @return The ongoing definition of a match
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	T or(Condition condition);
 
 	/**
@@ -74,7 +73,7 @@ public interface ExposesLogicalOperators<T> {
 	 * @param pathPattern An additional pattern to include in the conditions
 	 * @return The ongoing definition of a match
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default T or(RelationshipPattern pathPattern) {
 		return this.or(RelationshipPatternCondition.of(pathPattern));
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 import java.util.Collection;
@@ -41,7 +40,7 @@ public interface ExposesMatch {
 	 * @param pattern The patterns to match
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingWithoutWhere match(PatternElement... pattern) {
 		return this.match(false, pattern);
 	}
@@ -52,7 +51,7 @@ public interface ExposesMatch {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2021.2.2
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingWithoutWhere match(Collection<? extends PatternElement> pattern) {
 		return this.match(pattern.toArray(new PatternElement[] {}));
 	}
@@ -63,7 +62,7 @@ public interface ExposesMatch {
 	 * @param pattern The patterns to match
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingWithoutWhere optionalMatch(PatternElement... pattern) {
 		return this.match(true, pattern);
 	}
@@ -75,7 +74,7 @@ public interface ExposesMatch {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2021.2.2
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingWithoutWhere optionalMatch(Collection<? extends PatternElement> pattern) {
 		return this.optionalMatch(pattern.toArray(pattern.toArray(new PatternElement[] {})));
 	}
@@ -88,6 +87,6 @@ public interface ExposesMatch {
 	 * @return An ongoing match that is used to specify an optional where and a required return clause
 	 * @since 2020.1.3
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingWithoutWhere match(boolean optional, PatternElement... pattern);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMerge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMerge.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
@@ -38,6 +37,6 @@ public interface ExposesMerge {
 	 * @return An ongoing merge
 	 * @see Cypher#merge(PatternElement...)
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingMerge merge(PatternElement... pattern);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesPatternLengthAccessors.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesPatternLengthAccessors.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This interface is used to derive new relationship patterns from existing {@link Relationship relationships} or {@link RelationshipChain chains of relationships}
@@ -41,7 +39,6 @@ public interface ExposesPatternLengthAccessors<T extends RelationshipPattern> {
 	 * @return the new relationship
 	 * @since 1.1.1
 	 */
-	@NotNull @Contract(pure = true)
 	T unbounded();
 
 	/**
@@ -50,7 +47,6 @@ public interface ExposesPatternLengthAccessors<T extends RelationshipPattern> {
 	 * @param minimum the new minimum
 	 * @return the new relationship
 	 */
-	@NotNull @Contract(pure = true)
 	T min(Integer minimum);
 
 	/**
@@ -59,7 +55,6 @@ public interface ExposesPatternLengthAccessors<T extends RelationshipPattern> {
 	 * @param maximum the new maximum
 	 * @return the new relationship
 	 */
-	@NotNull @Contract(pure = true)
 	T max(Integer maximum);
 
 	/**
@@ -69,6 +64,5 @@ public interface ExposesPatternLengthAccessors<T extends RelationshipPattern> {
 	 * @param maximum the new maximum
 	 * @return the new relationship
 	 */
-	@NotNull @Contract(pure = true)
 	T length(Integer minimum, Integer maximum);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
@@ -20,8 +20,6 @@ package org.neo4j.cypherdsl.core;
 
 import java.util.Map;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A container that exposes methods to add properties with values to nodes or relationships.
@@ -40,7 +38,6 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
 	 * @return The new property container.
 	 */
-	@NotNull @Contract(pure = true)
 	T withProperties(MapExpression newProperties);
 
 	/**
@@ -50,7 +47,6 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}.
 	 * @return The new property container.
 	 */
-	@NotNull @Contract(pure = true)
 	T withProperties(Object... keysAndValues);
 
 	/**
@@ -59,6 +55,5 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	 * @param newProperties A map with the new properties
 	 * @return The new property container.
 	 */
-	@NotNull @Contract(pure = true)
 	T withProperties(Map<String, Object> newProperties);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesRelationships.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesRelationships.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A marker interface for things that expose methods to create new relationships to other elements.
@@ -41,7 +39,6 @@ public interface ExposesRelationships<T extends RelationshipPattern & ExposesPat
 	 * @param types The types to match
 	 * @return An ongoing relationship definition, that can be used to specify the type
 	 */
-	@NotNull @Contract(pure = true)
 	T relationshipTo(Node other, String... types);
 
 	/**
@@ -51,7 +48,6 @@ public interface ExposesRelationships<T extends RelationshipPattern & ExposesPat
 	 * @param types The types to match
 	 * @return An ongoing relationship definition, that can be used to specify the type
 	 */
-	@NotNull @Contract(pure = true)
 	T relationshipFrom(Node other, String... types);
 
 	/**
@@ -61,7 +57,6 @@ public interface ExposesRelationships<T extends RelationshipPattern & ExposesPat
 	 * @param types The types to match
 	 * @return An ongoing relationship definition, that can be used to specify the type
 	 */
-	@NotNull @Contract(pure = true)
 	T relationshipBetween(Node other, String... types);
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 import java.util.Arrays;
@@ -43,7 +42,7 @@ public interface ExposesReturning {
 	 * @param variables The named things to return
 	 * @return A build step with a defined list of things to return.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingAndReturn returning(String... variables) {
 		return returning(Expressions.createSymbolicNames(variables));
 	}
@@ -54,7 +53,7 @@ public interface ExposesReturning {
 	 * @param variables The named things to return
 	 * @return A build step with a defined list of things to return.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingAndReturn returning(Named... variables) {
 		return returning(Expressions.createSymbolicNames(variables));
 	}
@@ -65,7 +64,7 @@ public interface ExposesReturning {
 	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
 	 * @return A match that can be build now
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingAndReturn returning(Expression... expressions) {
 		return returning(expressions == null ? null : Arrays.asList(expressions));
 	}
@@ -76,7 +75,7 @@ public interface ExposesReturning {
 	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
 	 * @return A match that can be build now
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingAndReturn returning(Collection<? extends Expression> expressions);
 
 	/**
@@ -87,7 +86,7 @@ public interface ExposesReturning {
 	 * @param variables The variables to return
 	 * @return A build step with a defined list of things to return.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingAndReturn returningDistinct(String... variables) {
 		return returningDistinct(Expressions.createSymbolicNames(variables));
 	}
@@ -98,7 +97,7 @@ public interface ExposesReturning {
 	 * @param variables The named things to return
 	 * @return A build step with a defined list of things to return.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingAndReturn returningDistinct(Named... variables) {
 		return returningDistinct(Expressions.createSymbolicNames(variables));
 	}
@@ -109,7 +108,7 @@ public interface ExposesReturning {
 	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
 	 * @return A match that can be build now
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingReadingAndReturn returningDistinct(Expression... expressions) {
 		return returningDistinct(expressions == null ? null : Arrays.asList(expressions));
 	}
@@ -120,7 +119,7 @@ public interface ExposesReturning {
 	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
 	 * @return A match that can be build now
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions);
 
 	/**
@@ -132,6 +131,6 @@ public interface ExposesReturning {
 	 * @return A match that can be build now
 	 * @since 2021.2.1
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	StatementBuilder.OngoingReadingAndReturn returningRaw(Expression rawExpression);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSubqueryCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSubqueryCall.java
@@ -23,7 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Arrays;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.StatementBuilder.BuildableStatement;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithoutWhere;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
@@ -62,7 +61,7 @@ public interface ExposesSubqueryCall {
 	 * @param statement The statement representing the subquery.
 	 * @return An ongoing reading
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default BuildableSubquery call(Statement statement) {
 		return call(statement, new IdentifiableElement[0]);
 	}
@@ -81,7 +80,7 @@ public interface ExposesSubqueryCall {
 	 * @return An ongoing reading
 	 * @since 2021.3.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default BuildableSubquery call(Statement statement, String... imports) {
 		return call(statement, Arrays.stream(imports).map(SymbolicName::of).toArray(SymbolicName[]::new));
 	}
@@ -102,7 +101,7 @@ public interface ExposesSubqueryCall {
 	 * @return An ongoing reading
 	 * @since 2021.3.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	BuildableSubquery call(Statement statement, IdentifiableElement... imports);
 
 	/**
@@ -110,7 +109,7 @@ public interface ExposesSubqueryCall {
 	 * @param statement The sub-query to be called in transactions
 	 * @return Ongoing sub-query definition
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default BuildableSubquery callInTransactions(Statement statement) {
 		return callInTransactions(statement, null, new IdentifiableElement[0]);
 	}
@@ -123,7 +122,7 @@ public interface ExposesSubqueryCall {
 	 * @return Ongoing sub-query definition
 	 * @since 2023.10.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	BuildableSubquery callRawCypher(String rawCypher, Object... args);
 
 	/**
@@ -136,7 +135,7 @@ public interface ExposesSubqueryCall {
 	 * @return An ongoing reading, that is also buildable for outer queries that are void.
 	 * @since 2022.3.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default BuildableSubquery callInTransactions(Statement statement, Integer rows) {
 		return callInTransactions(statement, rows, new IdentifiableElement[0]);
 	}
@@ -151,7 +150,7 @@ public interface ExposesSubqueryCall {
 	 * @return An ongoing reading, that is also buildable for outer queries that are void.
 	 * @since 2022.3.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default BuildableSubquery callInTransactions(Statement statement, String... imports) {
 		return callInTransactions(statement, null, Arrays.stream(imports).map(SymbolicName::of).toArray(SymbolicName[]::new));
 	}
@@ -167,7 +166,7 @@ public interface ExposesSubqueryCall {
 	 * @return An ongoing reading, that is also buildable for outer queries that are void.
 	 * @since 2022.3.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default BuildableSubquery callInTransactions(Statement statement, Integer rows, String... imports) {
 		return callInTransactions(statement, rows, Arrays.stream(imports).map(SymbolicName::of).toArray(SymbolicName[]::new));
 	}
@@ -199,6 +198,6 @@ public interface ExposesSubqueryCall {
 	 * @return An ongoing reading, that is also buildable for outer queries that are void.
 	 * @since 2022.3.0
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	BuildableSubquery callInTransactions(Statement statement, Integer rows, IdentifiableElement... imports);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesUnwind.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesUnwind.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
@@ -39,7 +38,7 @@ public interface ExposesUnwind {
 	 * @param expressions The things to unwind.
 	 * @return An ongoing definition of an unwind.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingUnwind unwind(Expression... expressions) {
 		return unwind(Cypher.listOf(expressions));
 	}
@@ -50,7 +49,7 @@ public interface ExposesUnwind {
 	 * @param variable The thing to unwind.
 	 * @return An ongoing definition of an unwind.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default StatementBuilder.OngoingUnwind unwind(String variable) {
 		return unwind(Cypher.name(variable));
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWhere.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWhere.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
@@ -43,7 +42,7 @@ public interface ExposesWhere<T> {
 	 * @param condition The new condition, must not be {@literal null}
 	 * @return A match or call restricted by a where clause with no return items yet.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	T where(Condition condition);
 
 	/**
@@ -56,7 +55,7 @@ public interface ExposesWhere<T> {
 	 * @return A match or a call restricted by a where clause with no return items yet.
 	 * @since 1.0.1
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	default T where(RelationshipPattern pathPattern) {
 
 		Assertions.notNull(pathPattern, "The path pattern must not be null.");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWith.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWith.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
@@ -44,7 +43,6 @@ public interface ExposesWith {
 	 * @param variables The variables to pass on to the next part
 	 * @return A match that can be build now
 	 */
-	@NotNull
 	@CheckReturnValue
 	default OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
 		return with(Expressions.createSymbolicNames(variables));
@@ -56,7 +54,6 @@ public interface ExposesWith {
 	 * @param elements The variables to pass on to the next part
 	 * @return A match that can be build now
 	 */
-	@NotNull
 	@CheckReturnValue
 	default OrderableOngoingReadingAndWithWithoutWhere with(IdentifiableElement... elements) {
 		return with(Arrays.asList(elements));
@@ -68,7 +65,6 @@ public interface ExposesWith {
 	 * @param elements The expressions to be returned. Must not be null and be at least one expression.
 	 * @return A match that can be build now
 	 */
-	@NotNull
 	@CheckReturnValue
 	OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements);
 
@@ -79,7 +75,6 @@ public interface ExposesWith {
 	 * @return A match that can be build now
 	 * @see #withDistinct(IdentifiableElement...)
 	 */
-	@NotNull
 	@CheckReturnValue
 	default OrderableOngoingReadingAndWithWithoutWhere withDistinct(String... variables) {
 		return withDistinct(Expressions.createSymbolicNames(variables));
@@ -92,7 +87,6 @@ public interface ExposesWith {
 	 * @return A match that can be build now
 	 * @see #withDistinct(IdentifiableElement...)
 	 */
-	@NotNull
 	@CheckReturnValue
 	default OrderableOngoingReadingAndWithWithoutWhere withDistinct(IdentifiableElement... elements) {
 		return withDistinct(Arrays.asList(elements));
@@ -104,7 +98,6 @@ public interface ExposesWith {
 	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
 	 * @return A match that can be build now
 	 */
-	@NotNull
 	@CheckReturnValue
 	OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> expressions);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -43,7 +41,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new condition
 	 * @since 2022.7.0
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition includesAll(Expression rhs) {
 		return Conditions.includesAll(this, rhs);
 	}
@@ -55,7 +52,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new condition
 	 * @since 2022.7.0
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition includesAny(Expression rhs) {
 		return Conditions.includesAny(this, rhs);
 	}
@@ -66,7 +62,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param alias The alias to use
 	 * @return An aliased expression.
 	 */
-	@NotNull @Contract(pure = true)
 	default AliasedExpression as(String alias) {
 
 		Assertions.hasText(alias, "The alias may not be null or empty.");
@@ -85,7 +80,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return The size of this expression (Either the number of items in a list or the number of characters in a string expression).
 	 * @since 2022.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	default Expression size() {
 
 		return Functions.size(this);
@@ -99,7 +93,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @see #size()
 	 * @since 2022.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition hasSize(Expression expectedSize) {
 
 		return Functions.size(this).isEqualTo(expectedSize);
@@ -112,7 +105,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return An aliased expression.
 	 * @since 2021.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	default AliasedExpression as(SymbolicName alias) {
 
 		Assertions.notNull(alias, "The alias may not be null.");
@@ -125,7 +117,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return this expression as a condition. Will return the same instance if it is already a condition.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition asCondition() {
 		return this instanceof Condition condition ? condition : new ExpressionCondition(this);
 	}
@@ -136,7 +127,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isEqualTo(Expression rhs) {
 		return Conditions.isEqualTo(this, rhs);
 	}
@@ -147,7 +137,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition eq(Expression rhs) {
 		return isEqualTo(rhs);
 	}
@@ -158,7 +147,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isNotEqualTo(Expression rhs) {
 		return Conditions.isNotEqualTo(this, rhs);
 	}
@@ -169,7 +157,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition ne(Expression rhs) {
 		return isNotEqualTo(rhs);
 	}
@@ -180,7 +167,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition lt(Expression rhs) {
 		return Conditions.lt(this, rhs);
 	}
@@ -191,7 +177,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition lte(Expression rhs) {
 		return Conditions.lte(this, rhs);
 	}
@@ -202,7 +187,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition gt(Expression rhs) {
 		return Conditions.gt(this, rhs);
 	}
@@ -213,7 +197,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param rhs The right hand side of the condition
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition gte(Expression rhs) {
 		return Conditions.gte(this, rhs);
 	}
@@ -223,7 +206,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isTrue() {
 		return Conditions.isEqualTo(this, Cypher.literalTrue());
 	}
@@ -233,7 +215,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A new condition
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isFalse() {
 		return Conditions.isEqualTo(this, Cypher.literalFalse());
 	}
@@ -244,7 +225,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param expression The expression to match against. Must evaluate into a string during runtime.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition matches(Expression expression) {
 		return Conditions.matches(this, expression);
 	}
@@ -255,7 +235,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param pattern The pattern to match
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition matches(String pattern) {
 		return Conditions.matches(this, Cypher.literalOf(pattern));
 	}
@@ -266,7 +245,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param expression The expression to match against. Must evaluate into a string during runtime.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition startsWith(Expression expression) {
 		return Conditions.startsWith(this, expression);
 	}
@@ -277,7 +255,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param expression The expression to match against. Must evaluate into a string during runtime.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition contains(Expression expression) {
 		return Conditions.contains(this, expression);
 	}
@@ -288,7 +265,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param expression The expression to match against. Must evaluate into a string during runtime.
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition endsWith(Expression expression) {
 		return Conditions.endsWith(this, expression);
 	}
@@ -299,7 +275,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param expression The expression to concat to this expression.
 	 * @return A new expression.
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation concat(Expression expression) {
 		return Operations.concat(this, expression);
 	}
@@ -311,7 +286,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation add(Expression addend) {
 		return Operations.add(this, addend);
 	}
@@ -323,7 +297,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation subtract(Expression subtrahend) {
 		return Operations.subtract(this, subtrahend);
 	}
@@ -335,7 +308,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation multiply(Expression multiplicand) {
 		return Operations.multiply(this, multiplicand);
 	}
@@ -347,7 +319,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 1.0.1
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation divide(Expression dividend) {
 		return Operations.divide(this, dividend);
 	}
@@ -358,7 +329,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param dividend The dividend
 	 * @return A new operation.
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation remainder(Expression dividend) {
 		return Operations.remainder(this, dividend);
 	}
@@ -369,7 +339,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param n power to raise this {@code Expression} to.
 	 * @return A new operation.
 	 */
-	@NotNull @Contract(pure = true)
 	default Operation pow(Expression n) {
 
 		return Operations.pow(this, n);
@@ -381,7 +350,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A condition based on this expression that evaluates to true when this expression is null.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isNull() {
 		return Conditions.isNull(this);
 	}
@@ -392,7 +360,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A condition based on this expression that evaluates to true when this expression is not null.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isNotNull() {
 		return Conditions.isNotNull(this);
 	}
@@ -404,7 +371,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @param haystack The expression to search for this expression
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition in(Expression haystack) {
 		return Comparison.create(this, Operator.IN, haystack);
 	}
@@ -414,7 +380,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A new condition.
 	 */
-	@NotNull @Contract(pure = true)
 	default Condition isEmpty() {
 
 		return Functions.size(this).isEqualTo(Cypher.literalOf(0L));
@@ -425,7 +390,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A sort item for this property in descending order
 	 */
-	@NotNull @Contract(pure = true)
 	default SortItem descending() {
 
 		return SortItem.create(this, SortItem.Direction.DESC);
@@ -436,7 +400,6 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 *
 	 * @return A sort item for this property in ascending order
 	 */
-	@NotNull @Contract(pure = true)
 	default SortItem ascending() {
 
 		return SortItem.create(this, SortItem.Direction.ASC);
@@ -449,14 +412,12 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return A new sort item.
 	 * @since 2021.4.1
 	 */
-	@NotNull @Contract(pure = true)
 	default SortItem sorted(SortItem.Direction direction) {
 
 		return SortItem.create(this, direction);
 	}
 
-	@Override @NotNull
-	default Property property(String... names) {
+	@Override default Property property(String... names) {
 
 		return InternalPropertyImpl.create(this, names);
 	}
@@ -476,8 +437,7 @@ public interface Expression extends Visitable, PropertyAccessor {
 	 * @return a new {@link Property} associated with this named container
 	 * @since 2024.1.0
 	 */
-	@Override @NotNull
-	default Property property(@NotNull Expression lookup) {
+	@Override default Property property(Expression lookup) {
 		return InternalPropertyImpl.create(this, lookup);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Statement.UnionQuery;
 
 /**
@@ -41,7 +39,6 @@ final class Expressions {
 	 * @return The immutable {@link CountExpression}
 	 * @since 2023.0.0
 	 */
-	@NotNull
 	static CountExpression count(PatternElement requiredPattern, PatternElement... patternElement) {
 		return CountExpression.count(Pattern.of(requiredPattern, patternElement));
 	}
@@ -53,7 +50,6 @@ final class Expressions {
 	 * @return The immutable {@link CountExpression}
 	 * @since 2023.0.0
 	 */
-	@NotNull
 	static CountExpression count(UnionQuery union) {
 		return CountExpression.count(union);
 	}
@@ -68,7 +64,6 @@ final class Expressions {
 	 * @return A counting sub-query.
 	 * @since 2023.1.0
 	 */
-	@NotNull
 	static CountExpression count(Statement statement, IdentifiableElement... imports) {
 		return CountExpression.count(statement, imports);
 	}
@@ -81,7 +76,7 @@ final class Expressions {
 	 * @return a count expression.
 	 * @since 2023.9.0
 	 */
-	static CountExpression count(List<PatternElement> pattern, @Nullable Where where) {
+	static CountExpression count(List<PatternElement> pattern, Where where) {
 
 		return CountExpression.count(pattern, where);
 	}
@@ -99,13 +94,11 @@ final class Expressions {
 			Arrays.stream(identifiableElements).map(IdentifiableElement::asExpression).toList());
 		var with = new With(false, returnItems, null, null, null, null);
 		return new SubqueryExpressionBuilder() {
-			@Override @NotNull
-			public CountExpression count(PatternElement requiredPattern, PatternElement... patternElement) {
+			@Override 		public CountExpression count(PatternElement requiredPattern, PatternElement... patternElement) {
 				return CountExpression.count(with, Pattern.of(requiredPattern, patternElement));
 			}
 
-			@Override @NotNull
-			public CountExpression count(UnionQuery union) {
+			@Override 		public CountExpression count(UnionQuery union) {
 				return CountExpression.count(with, union);
 			}
 
@@ -125,7 +118,6 @@ final class Expressions {
 	 * @return a collecting sub-query.
 	 * @since 2023.8.0
 	 */
-	@NotNull
 	static Expression collect(Statement statement) {
 
 		if (!statement.doesReturnOrYield()) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ForeignAdapter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ForeignAdapter.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an adapter that allows to turn foreign expressions into Cypher-DSL {@link Expression expressions}.
@@ -42,7 +40,6 @@ public interface ForeignAdapter<FE> {
 	 * @return A condition
 	 * @throws IllegalArgumentException if the expression doesn't resolve into something boolean
 	 */
-	@NotNull @Contract(pure = true)
 	Condition asCondition();
 
 	/**
@@ -50,7 +47,6 @@ public interface ForeignAdapter<FE> {
 	 *
 	 * @return A native expression
 	 */
-	@NotNull @Contract(pure = true)
 	Expression asExpression();
 
 	/**
@@ -59,7 +55,6 @@ public interface ForeignAdapter<FE> {
 	 * @return A node
 	 * @throws IllegalArgumentException if the expression doesn't describe something that can be used to describe a node
 	 */
-	@NotNull @Contract(pure = true)
 	Node asNode();
 
 	/**
@@ -68,7 +63,6 @@ public interface ForeignAdapter<FE> {
 	 * @return A node
 	 * @throws IllegalArgumentException if the expression doesn't describe something that can be used to describe a node
 	 */
-	@NotNull @Contract(pure = true)
 	Relationship asRelationship();
 
 	/**
@@ -78,6 +72,5 @@ public interface ForeignAdapter<FE> {
 	 * @return A symbolic name
 	 * @throws IllegalArgumentException if a name cannot be derived from the expression.
 	 */
-	@NotNull @Contract(pure = true)
 	SymbolicName asName();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -20,8 +20,6 @@ package org.neo4j.cypherdsl.core;
 
 import java.util.TimeZone;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.BuiltInFunctions.Aggregates;
 import org.neo4j.cypherdsl.core.BuiltInFunctions.Lists;
 import org.neo4j.cypherdsl.core.BuiltInFunctions.Predicates;
@@ -49,10 +47,9 @@ final class Functions {
 	 * @deprecated see {@link #elementId(Node)} for a replacement. Neo4j the database will remove support for {@code id(n)}
 	 * at some point.
 	 */
-	@NotNull @Contract(pure = true)
 	@Deprecated(since = "2023.3.0")
 	@SuppressWarnings({ "squid:S1133" }) // Yes, I promise, this will be removed at some point, but not yet.
-	static FunctionInvocation id(@NotNull Node node) {
+	static FunctionInvocation id(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 
@@ -68,10 +65,9 @@ final class Functions {
 	 * @deprecated see {@link #elementId(Relationship)} for a replacement. Neo4j the database will remove support for
 	 * {@code id(n)} at some point.
 	 */
-	@NotNull @Contract(pure = true)
 	@Deprecated(since = "2023.3.0")
 	@SuppressWarnings({ "squid:S1133" }) // Yes, I promise, this will be removed at some point, but not yet.
-	static FunctionInvocation id(@NotNull Relationship relationship) {
+	static FunctionInvocation id(Relationship relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));
 
@@ -84,9 +80,8 @@ final class Functions {
 	 * @param node The node for which the element id should be retrieved
 	 * @return A function call for {@code elementId()} on a node.
 	 */
-	@NotNull @Contract(pure = true)
 	@Neo4jVersion(minimum = "5.0.0")
-	static FunctionInvocation elementId(@NotNull Node node) {
+	static FunctionInvocation elementId(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 
@@ -99,9 +94,8 @@ final class Functions {
 	 * @param relationship The relationship for which the element id should be retrieved
 	 * @return A function call for {@code elementId()} on a relationship.
 	 */
-	@NotNull @Contract(pure = true)
 	@Neo4jVersion(minimum = "5.0.0")
-	static FunctionInvocation elementId(@NotNull Relationship relationship) {
+	static FunctionInvocation elementId(Relationship relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));
 
@@ -116,8 +110,7 @@ final class Functions {
 	 * @return A function call for {@code keys()} on an expression.
 	 * @since 2021.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation keys(@NotNull Node node) {
+	static FunctionInvocation keys(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 		return keys(node.getRequiredSymbolicName());
@@ -131,8 +124,7 @@ final class Functions {
 	 * @return A function call for {@code keys()} on an expression.
 	 * @since 2021.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation keys(@NotNull Relationship relationship) {
+	static FunctionInvocation keys(Relationship relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));
 		return keys(relationship.getRequiredSymbolicName());
@@ -146,8 +138,7 @@ final class Functions {
 	 * @return A function call for {@code keys()} on an expression.
 	 * @since 2021.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation keys(@NotNull Expression expression) {
+	static FunctionInvocation keys(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 
@@ -162,8 +153,7 @@ final class Functions {
 	 * @param node The node for which the labels should be retrieved
 	 * @return A function call for {@code labels()} on a node.
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation labels(@NotNull Node node) {
+	static FunctionInvocation labels(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 
@@ -180,8 +170,7 @@ final class Functions {
 	 * @return A function call for {@code labels()} on a node.
 	 * @since 2023.2.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation labels(@NotNull SymbolicName node) {
+	static FunctionInvocation labels(SymbolicName node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 
@@ -195,8 +184,7 @@ final class Functions {
 	 * @param relationship The relationship for which the type should be retrieved
 	 * @return A function call for {@code type()} on a relationship.
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation type(@NotNull Relationship relationship) {
+	static FunctionInvocation type(Relationship relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));
 
@@ -213,8 +201,7 @@ final class Functions {
 	 * @return A function call for {@code type()} on a relationship.
 	 * @since 2023.2.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation type(@NotNull SymbolicName relationship) {
+	static FunctionInvocation type(SymbolicName relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));
 
@@ -226,8 +213,7 @@ final class Functions {
 	 * @return A function call for {@code count()} for one named node
 	 * @see #count(Expression)
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation count(@NotNull Node node) {
+	static FunctionInvocation count(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 
@@ -241,7 +227,6 @@ final class Functions {
 	 * @param expression An expression describing the things to count.
 	 * @return A function call for {@code count()} for an expression like {@link Cypher#asterisk()} etc.
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation count(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.COUNT, expression);
@@ -254,8 +239,7 @@ final class Functions {
 	 * @return A function call for {@code count()} for one named node
 	 * @see #countDistinct(Expression)
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation countDistinct(@NotNull Node node) {
+	static FunctionInvocation countDistinct(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
 
@@ -269,7 +253,6 @@ final class Functions {
 	 * @param expression An expression describing the things to count.
 	 * @return A function call for {@code count()} for an expression like {@link Cypher#asterisk()} etc.
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation countDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.COUNT, expression);
@@ -281,7 +264,6 @@ final class Functions {
 	 * @param node The node who's properties should be returned.
 	 * @return A function call for {@code properties())}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation properties(Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
@@ -295,7 +277,6 @@ final class Functions {
 	 * @param relationship The relationship who's properties should be returned.
 	 * @return A function call for {@code properties())}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation properties(Relationship relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));
@@ -309,7 +290,6 @@ final class Functions {
 	 * @param map The map who's properties should be returned.
 	 * @return A function call for {@code properties())}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation properties(MapExpression map) {
 
 		return FunctionInvocation.create(Scalars.PROPERTIES, map);
@@ -322,7 +302,6 @@ final class Functions {
 	 * @param expressions One or more expressions to be coalesced
 	 * @return A function call for {@code coalesce}.
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation coalesce(Expression... expressions) {
 
 		return FunctionInvocation.create(Scalars.COALESCE, expressions);
@@ -337,7 +316,6 @@ final class Functions {
 	 * @return A function call for {@code left()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation left(Expression expression, Expression length) {
 
 		if (expression != null && length == null) {
@@ -357,8 +335,7 @@ final class Functions {
 	 * @return A function call for {@code ltrim()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation ltrim(@NotNull Expression expression) {
+	static FunctionInvocation ltrim(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.LTRIM, expressionOrNullLit(expression));
@@ -374,7 +351,6 @@ final class Functions {
 	 * @return A function call for {@code replace()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation replace(Expression original, Expression search, Expression replace) {
 
 		return FunctionInvocation.create(Strings.REPLACE, expressionOrNullLit(original), expressionOrNullLit(search),
@@ -389,8 +365,7 @@ final class Functions {
 	 * @return A function call for {@code reverse()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation reverse(@NotNull Expression original) {
+	static FunctionInvocation reverse(Expression original) {
 
 		Assertions.notNull(original, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.REVERSE, expressionOrNullLit(original));
@@ -405,7 +380,6 @@ final class Functions {
 	 * @return A function call for {@code right()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation right(Expression expression, Expression length) {
 
 		if (expression != null && length == null) {
@@ -425,8 +399,7 @@ final class Functions {
 	 * @return A function call for {@code rtrim()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation rtrim(@NotNull Expression expression) {
+	static FunctionInvocation rtrim(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.RTRIM, expressionOrNullLit(expression));
@@ -442,7 +415,6 @@ final class Functions {
 	 * @return A function call for {@code substring()}
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation substring(Expression original, Expression start, Expression length) {
 
 		Assertions.notNull(start, "start is required");
@@ -463,8 +435,7 @@ final class Functions {
 	 * @param expression An expression resolving to a string
 	 * @return A function call for {@code toLower()} for one expression
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toLower(@NotNull Expression expression) {
+	static FunctionInvocation toLower(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.TO_LOWER, expressionOrNullLit(expression));
@@ -478,8 +449,7 @@ final class Functions {
 	 * @return A function call for {@code toLower()} for one expression
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toUpper(@NotNull Expression expression) {
+	static FunctionInvocation toUpper(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.TO_UPPER, expressionOrNullLit(expression));
@@ -493,8 +463,7 @@ final class Functions {
 	 * @return A function call for {@code trim()} for one expression
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation trim(@NotNull Expression expression) {
+	static FunctionInvocation trim(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.TRIM, expression);
@@ -509,8 +478,7 @@ final class Functions {
 	 * @return A function call for {@code split()}
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation split(@NotNull Expression expression, @NotNull Expression delimiter) {
+	static FunctionInvocation split(Expression expression, Expression delimiter) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		Assertions.notNull(delimiter, "The delimiter is required.");
@@ -526,8 +494,7 @@ final class Functions {
 	 * @return A function call for {@code split()}
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation split(@NotNull Expression expression, @NotNull String delimiter) {
+	static FunctionInvocation split(Expression expression, String delimiter) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		Assertions.notNull(delimiter, "The delimiter is required.");
@@ -544,7 +511,6 @@ final class Functions {
 	 * @param expression The expression who's size is to be returned
 	 * @return A function call for {@code size()} for one expression
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation size(Expression expression) {
 
 		return FunctionInvocation.create(Scalars.SIZE, expression);
@@ -559,7 +525,6 @@ final class Functions {
 	 * @param pattern The pattern for which {@code size()} should be invoked.
 	 * @return A function call for {@code size()} for a pattern
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation size(RelationshipPattern pattern) {
 
 		return FunctionInvocation.create(Scalars.SIZE, pattern);
@@ -572,7 +537,6 @@ final class Functions {
 	 * @param expression The expression who's existence is to be evaluated
 	 * @return A function call for {@code exists()} for one expression
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation exists(Expression expression) {
 
 		return FunctionInvocation.create(Predicates.EXISTS, expression);
@@ -587,8 +551,7 @@ final class Functions {
 	 * @param point2 Point 2
 	 * @return A function call for {@code distance()}
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation distance(@NotNull Expression point1, @NotNull Expression point2) {
+	static FunctionInvocation distance(Expression point1, Expression point2) {
 
 		Assertions.notNull(point1, "The distance function requires two points.");
 		Assertions.notNull(point2, "The distance function requires two points.");
@@ -603,7 +566,6 @@ final class Functions {
 	 * @param parameterMap The map of parameters for {@code point()}
 	 * @return A function call for {@code point()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation point(MapExpression parameterMap) {
 
 		return point((Expression) parameterMap);
@@ -619,7 +581,6 @@ final class Functions {
 	 * @return A function call for {@code point()}
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation point(Expression expression) {
 
 		return FunctionInvocation.create(Spatials.POINT, expression);
@@ -633,7 +594,6 @@ final class Functions {
 	 * @return A function call for {@code point()}
 	 * @since 2022.7.3
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation point(Parameter<?> parameter) {
 
 		return FunctionInvocation.create(Spatials.POINT, parameter);
@@ -647,7 +607,6 @@ final class Functions {
 	 * @return A function call for {@code point()}
 	 * @since 2022.7.3
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation cartesian(double x, double y) {
 
 		return point(Cypher.mapOf("x", Cypher.literalOf(x), "y", Cypher.literalOf(y)));
@@ -661,7 +620,6 @@ final class Functions {
 	 * @return A function call for {@code point()}
 	 * @since 2022.7.3
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation coordinate(double longitude, double latitude) {
 
 		return point(Cypher.mapOf("longitude", Cypher.literalOf(longitude), "latitude", Cypher.literalOf(latitude)));
@@ -689,7 +647,6 @@ final class Functions {
 	 * @param expression The things to average
 	 * @return A function call for {@code avg()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation avg(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.AVG, expression);
@@ -702,7 +659,6 @@ final class Functions {
 	 * @param expression The things to average
 	 * @return A function call for {@code avg()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation avgDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.AVG, expression);
@@ -715,8 +671,7 @@ final class Functions {
 	 * @return A function call for {@code collect()}
 	 * @see #collect(Expression)
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation collect(@NotNull Named variable) {
+	static FunctionInvocation collect(Named variable) {
 
 		Assertions.notNull(variable, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_VARIABLE_REQUIRED));
 
@@ -730,8 +685,7 @@ final class Functions {
 	 * @return A function call for {@code collect()}
 	 * @see #collect(Expression)
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation collectDistinct(@NotNull Named variable) {
+	static FunctionInvocation collectDistinct(Named variable) {
 
 		Assertions.notNull(variable, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_VARIABLE_REQUIRED));
 
@@ -745,7 +699,6 @@ final class Functions {
 	 * @param expression The things to collect
 	 * @return A function call for {@code collect()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation collect(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.COLLECT, expression);
@@ -758,7 +711,6 @@ final class Functions {
 	 * @param expression The things to collect
 	 * @return A function call for {@code collect()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation collectDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.COLLECT, expression);
@@ -771,7 +723,6 @@ final class Functions {
 	 * @param expression A list from which the maximum element value is returned
 	 * @return A function call for {@code max()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation max(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.MAX, expression);
@@ -784,7 +735,6 @@ final class Functions {
 	 * @param expression A list from which the maximum element value is returned
 	 * @return A function call for {@code max()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation maxDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.MAX, expression);
@@ -797,7 +747,6 @@ final class Functions {
 	 * @param expression A list from which the minimum element value is returned
 	 * @return A function call for {@code min()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation min(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.MIN, expression);
@@ -810,7 +759,6 @@ final class Functions {
 	 * @param expression A list from which the minimum element value is returned
 	 * @return A function call for {@code min()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation minDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.MIN, expression);
@@ -833,7 +781,6 @@ final class Functions {
 	 * @param percentile A numeric value between 0.0 and 1.0
 	 * @return A function call for {@code percentileCont()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation percentileCont(Expression expression, Number percentile) {
 
 		assertPercentileArguments(Aggregates.PERCENTILE_CONT, expression, percentile);
@@ -849,7 +796,6 @@ final class Functions {
 	 * @param percentile A numeric value between 0.0 and 1.0
 	 * @return A function call for {@code percentileCont()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation percentileContDistinct(Expression expression, Number percentile) {
 
 		assertPercentileArguments(Aggregates.PERCENTILE_CONT, expression, percentile);
@@ -865,7 +811,6 @@ final class Functions {
 	 * @param percentile A numeric value between 0.0 and 1.0
 	 * @return A function call for {@code percentileDisc()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation percentileDisc(Expression expression, Number percentile) {
 
 		assertPercentileArguments(Aggregates.PERCENTILE_DISC, expression, percentile);
@@ -881,7 +826,6 @@ final class Functions {
 	 * @param percentile A numeric value between 0.0 and 1.0
 	 * @return A function call for {@code percentileDisc()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation percentileDiscDistinct(Expression expression, Number percentile) {
 
 		assertPercentileArguments(Aggregates.PERCENTILE_DISC, expression, percentile);
@@ -896,7 +840,6 @@ final class Functions {
 	 * @param expression A numeric expression
 	 * @return A function call for {@code stDev()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation stDev(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.ST_DEV, expression);
@@ -909,7 +852,6 @@ final class Functions {
 	 * @param expression A numeric expression
 	 * @return A function call for {@code stDev()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation stDevDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.ST_DEV, expression);
@@ -922,7 +864,6 @@ final class Functions {
 	 * @param expression A numeric expression
 	 * @return A function call for {@code stDevP()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation stDevP(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.ST_DEV_P, expression);
@@ -935,7 +876,6 @@ final class Functions {
 	 * @param expression A numeric expression
 	 * @return A function call for {@code stDevP()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation stDevPDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.ST_DEV_P, expression);
@@ -948,7 +888,6 @@ final class Functions {
 	 * @param expression An expression returning a set of numeric values
 	 * @return A function call for {@code sum()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation sum(Expression expression) {
 
 		return FunctionInvocation.create(Aggregates.SUM, expression);
@@ -961,7 +900,6 @@ final class Functions {
 	 * @param expression An expression returning a set of numeric values
 	 * @return A function call for {@code sum()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation sumDistinct(Expression expression) {
 
 		return FunctionInvocation.createDistinct(Aggregates.SUM, expression);
@@ -973,7 +911,6 @@ final class Functions {
 	 * @return A function call for {@code range()}
 	 * @see #range(Expression, Expression)
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation range(Integer start, Integer end) {
 
 		return range(Cypher.literalOf(start), Cypher.literalOf(end));
@@ -985,8 +922,7 @@ final class Functions {
 	 * @return A function call for {@code range()}
 	 * @see #range(Expression, Expression, Expression)
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation range(@NotNull Expression start, @NotNull Expression end) {
+	static FunctionInvocation range(Expression start, Expression end) {
 		return range(start, end, null);
 	}
 
@@ -1000,8 +936,7 @@ final class Functions {
 	 * @return A function call for {@code range()}
 	 * @see #range(Expression, Expression, Expression)
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation range(@NotNull Integer start, @NotNull Integer end, Integer step) {
+	static FunctionInvocation range(Integer start, Integer end, Integer step) {
 
 		return range(Cypher.literalOf(start), Cypher.literalOf(end), Cypher.literalOf(step));
 	}
@@ -1015,8 +950,7 @@ final class Functions {
 	 * @param step  the range's step
 	 * @return A function call for {@code range()}
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation range(@NotNull Expression start, @NotNull Expression end, Expression step) {
+	static FunctionInvocation range(Expression start, Expression end, Expression step) {
 
 		Assertions.notNull(start, "The expression for range is required.");
 		Assertions.notNull(end, "The expression for range is required.");
@@ -1035,7 +969,6 @@ final class Functions {
 	 * @param expression A list from which the head element is returned
 	 * @return A function call for {@code head()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation head(Expression expression) {
 
 		return FunctionInvocation.create(Scalars.HEAD, expression);
@@ -1048,7 +981,6 @@ final class Functions {
 	 * @param expression A list from which the last element is returned
 	 * @return A function call for {@code last()}
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation last(Expression expression) {
 
 		return FunctionInvocation.create(Scalars.LAST, expression);
@@ -1062,8 +994,7 @@ final class Functions {
 	 * @return A function call for {@code nodes()} on a path.
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation nodes(@NotNull NamedPath path) {
+	static FunctionInvocation nodes(NamedPath path) {
 
 		Assertions.notNull(path, "The path for nodes is required.");
 		return FunctionInvocation.create(Lists.NODES,
@@ -1079,8 +1010,7 @@ final class Functions {
 	 * @return A function call for {@code nodes{}} on a path represented by a symbolic name.
 	 * @since 2020.1.5
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation nodes(@NotNull SymbolicName symbolicName) {
+	static FunctionInvocation nodes(SymbolicName symbolicName) {
 
 		Assertions.notNull(symbolicName, "The symbolic name of the path for nodes is required.");
 		return FunctionInvocation.create(Lists.NODES, symbolicName);
@@ -1094,8 +1024,7 @@ final class Functions {
 	 * @return A function call for {@code relationships()} on a path.
 	 * @since 2020.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation relationships(@NotNull NamedPath path) {
+	static FunctionInvocation relationships(NamedPath path) {
 
 		Assertions.notNull(path, "The path for relationships is required.");
 		return FunctionInvocation.create(Lists.RELATIONSHIPS,
@@ -1111,8 +1040,7 @@ final class Functions {
 	 * @return A function call for {@code relationships()} on a path represented by a symbolic name.
 	 * @since 2020.1.5
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation relationships(@NotNull SymbolicName symbolicName) {
+	static FunctionInvocation relationships(SymbolicName symbolicName) {
 
 		Assertions.notNull(symbolicName, "The symbolic name of the path for relationships is required.");
 		return FunctionInvocation.create(Lists.RELATIONSHIPS, symbolicName);
@@ -1126,8 +1054,7 @@ final class Functions {
 	 * @return A function call for {@code startNode()} on a path.
 	 * @since 2020.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation startNode(@NotNull Relationship relationship) {
+	static FunctionInvocation startNode(Relationship relationship) {
 
 		Assertions.notNull(relationship, "The relationship for endNode is required.");
 		return FunctionInvocation.create(Scalars.START_NODE,
@@ -1143,8 +1070,7 @@ final class Functions {
 	 * @return A function call for {@code endNode()} on a path.
 	 * @since 2020.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation endNode(@NotNull Relationship relationship) {
+	static FunctionInvocation endNode(Relationship relationship) {
 
 		Assertions.notNull(relationship, "The relationship for endNode is required.");
 		return FunctionInvocation.create(Scalars.END_NODE,
@@ -1160,7 +1086,6 @@ final class Functions {
 	 * @return A function call for {@code date()}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation date() {
 
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE);
@@ -1176,7 +1101,6 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation calendarDate(Integer year, Integer month, Integer day) {
 
 		Assertions.notNull(year, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_YEAR_REQUIRED));
@@ -1196,7 +1120,6 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation weekDate(Integer year, Integer week, Integer dayOfWeek) {
 
 		Assertions.notNull(year, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_YEAR_REQUIRED));
@@ -1228,7 +1151,6 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation quarterDate(Integer year, Integer quarter, Integer dayOfQuarter) {
 
 		Assertions.notNull(year, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_YEAR_REQUIRED));
@@ -1256,7 +1178,6 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation ordinalDate(Integer year, Integer ordinalDay) {
 
 		Assertions.notNull(year, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_YEAR_REQUIRED));
@@ -1280,8 +1201,7 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation date(@NotNull MapExpression components) {
+	static FunctionInvocation date(MapExpression components) {
 
 		Assertions.notNull(components, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_COMPONENTS_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, components);
@@ -1296,8 +1216,7 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation date(@NotNull String temporalValue) {
+	static FunctionInvocation date(String temporalValue) {
 
 		Assertions.hasText(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, Cypher.literalOf(temporalValue));
@@ -1312,8 +1231,7 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation date(@NotNull Expression temporalValue) {
+	static FunctionInvocation date(Expression temporalValue) {
 
 		Assertions.notNull(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, temporalValue);
@@ -1326,7 +1244,6 @@ final class Functions {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation datetime() {
 
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME);
@@ -1340,8 +1257,7 @@ final class Functions {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation datetime(@NotNull TimeZone timeZone) {
+	static FunctionInvocation datetime(TimeZone timeZone) {
 
 		Assertions.notNull(timeZone, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TZ_REQUIRED));
 		return FunctionInvocation
@@ -1357,8 +1273,7 @@ final class Functions {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation datetime(@NotNull MapExpression components) {
+	static FunctionInvocation datetime(MapExpression components) {
 
 		Assertions.notNull(components, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_COMPONENTS_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME, components);
@@ -1373,8 +1288,7 @@ final class Functions {
 	 * @return A function call for {@code datetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation datetime(@NotNull String temporalValue) {
+	static FunctionInvocation datetime(String temporalValue) {
 
 		Assertions.hasText(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME, Cypher.literalOf(temporalValue));
@@ -1389,8 +1303,7 @@ final class Functions {
 	 * @return A function call for {@code date({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation datetime(@NotNull Expression temporalValue) {
+	static FunctionInvocation datetime(Expression temporalValue) {
 
 		Assertions.notNull(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME, temporalValue);
@@ -1403,7 +1316,6 @@ final class Functions {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation localdatetime() {
 
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME);
@@ -1417,8 +1329,7 @@ final class Functions {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localdatetime(@NotNull TimeZone timeZone) {
+	static FunctionInvocation localdatetime(TimeZone timeZone) {
 
 		Assertions.notNull(timeZone, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TZ_REQUIRED));
 		return FunctionInvocation
@@ -1434,8 +1345,7 @@ final class Functions {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localdatetime(@NotNull MapExpression components) {
+	static FunctionInvocation localdatetime(MapExpression components) {
 
 		Assertions.notNull(components, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_COMPONENTS_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME, components);
@@ -1450,8 +1360,7 @@ final class Functions {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localdatetime(@NotNull String temporalValue) {
+	static FunctionInvocation localdatetime(String temporalValue) {
 
 		Assertions.hasText(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME, Cypher.literalOf(temporalValue));
@@ -1466,8 +1375,7 @@ final class Functions {
 	 * @return A function call for {@code localdatetime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localdatetime(@NotNull Expression temporalValue) {
+	static FunctionInvocation localdatetime(Expression temporalValue) {
 
 		Assertions.notNull(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME, temporalValue);
@@ -1480,7 +1388,6 @@ final class Functions {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation localtime() {
 
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME);
@@ -1494,8 +1401,7 @@ final class Functions {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localtime(@NotNull TimeZone timeZone) {
+	static FunctionInvocation localtime(TimeZone timeZone) {
 
 		Assertions.notNull(timeZone, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TZ_REQUIRED));
 		return FunctionInvocation
@@ -1511,8 +1417,7 @@ final class Functions {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localtime(@NotNull MapExpression components) {
+	static FunctionInvocation localtime(MapExpression components) {
 
 		Assertions.notNull(components, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_COMPONENTS_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME, components);
@@ -1527,8 +1432,7 @@ final class Functions {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localtime(@NotNull String temporalValue) {
+	static FunctionInvocation localtime(String temporalValue) {
 
 		Assertions.hasText(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME, Cypher.literalOf(temporalValue));
@@ -1543,8 +1447,7 @@ final class Functions {
 	 * @return A function call for {@code localtime({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation localtime(@NotNull Expression temporalValue) {
+	static FunctionInvocation localtime(Expression temporalValue) {
 
 		Assertions.notNull(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME, temporalValue);
@@ -1557,7 +1460,6 @@ final class Functions {
 	 * @return A function call for {@code time({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation time() {
 
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME);
@@ -1571,8 +1473,7 @@ final class Functions {
 	 * @return A function call for {@code time({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation time(@NotNull TimeZone timeZone) {
+	static FunctionInvocation time(TimeZone timeZone) {
 
 		Assertions.notNull(timeZone, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TZ_REQUIRED));
 		return FunctionInvocation
@@ -1592,8 +1493,7 @@ final class Functions {
 	 * @return A function call for {@code time({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation time(@NotNull MapExpression components) {
+	static FunctionInvocation time(MapExpression components) {
 
 		Assertions.notNull(components, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_COMPONENTS_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME, components);
@@ -1608,8 +1508,7 @@ final class Functions {
 	 * @return A function call for {@code time({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation time(@NotNull String temporalValue) {
+	static FunctionInvocation time(String temporalValue) {
 
 		Assertions.hasText(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME, Cypher.literalOf(temporalValue));
@@ -1624,8 +1523,7 @@ final class Functions {
 	 * @return A function call for {@code time({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation time(@NotNull Expression temporalValue) {
+	static FunctionInvocation time(Expression temporalValue) {
 
 		Assertions.notNull(temporalValue, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_TEMPORAL_VALUE_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME, temporalValue);
@@ -1640,8 +1538,7 @@ final class Functions {
 	 * @return A function call for {@code duration({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation duration(@NotNull MapExpression components) {
+	static FunctionInvocation duration(MapExpression components) {
 
 		Assertions.notNull(components, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_COMPONENTS_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DURATION, components);
@@ -1656,8 +1553,7 @@ final class Functions {
 	 * @return A function call for {@code duration({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation duration(@NotNull String temporalAmount) {
+	static FunctionInvocation duration(String temporalAmount) {
 
 		Assertions.hasText(temporalAmount, "The temporalAmount is required.");
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DURATION, Cypher.literalOf(temporalAmount));
@@ -1672,8 +1568,7 @@ final class Functions {
 	 * @return A function call for {@code duration({})}.
 	 * @since 2020.1.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation duration(@NotNull Expression temporalAmount) {
+	static FunctionInvocation duration(Expression temporalAmount) {
 
 		Assertions.notNull(temporalAmount, "The temporalAmount is required.");
 		return FunctionInvocation.create(BuiltInFunctions.Temporals.DURATION, temporalAmount);
@@ -1686,7 +1581,6 @@ final class Functions {
 	 * @return A function call for {@code shortestPath({})}.
 	 * @since 2020.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation shortestPath(Relationship relationship) {
 
 		return FunctionInvocation.create(Scalars.SHORTEST_PATH, relationship);
@@ -1699,8 +1593,7 @@ final class Functions {
 	 * @return An ongoing definition for a function call to {@code reduce({})}.
 	 * @since 2020.1.5
 	 */
-	@NotNull @Contract(pure = true)
-	static Reduction.OngoingDefinitionWithVariable reduce(@NotNull SymbolicName variable) {
+	static Reduction.OngoingDefinitionWithVariable reduce(SymbolicName variable) {
 
 		return Reduction.of(variable);
 	}
@@ -1713,8 +1606,7 @@ final class Functions {
 	 * @return A function call for {@code abs({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation abs(@NotNull Expression expression) {
+	static FunctionInvocation abs(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.ABS, expression);
@@ -1728,8 +1620,7 @@ final class Functions {
 	 * @return A function call for {@code ceil({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation ceil(@NotNull Expression expression) {
+	static FunctionInvocation ceil(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.CEIL, expression);
@@ -1743,8 +1634,7 @@ final class Functions {
 	 * @return A function call for {@code floor({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation floor(@NotNull Expression expression) {
+	static FunctionInvocation floor(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.FLOOR, expression);
@@ -1757,7 +1647,6 @@ final class Functions {
 	 * @return A function call for {@code rand({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation rand() {
 
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.RAND);
@@ -1773,7 +1662,6 @@ final class Functions {
 	 * @return A function call for {@code round({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation round(Expression value, Expression... expression) {
 
 		if (expression == null || expression.length == 0) {
@@ -1797,8 +1685,7 @@ final class Functions {
 	 * @return A function call for {@code sign({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation sign(@NotNull Expression expression) {
+	static FunctionInvocation sign(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.SIGN, expression);
@@ -1811,7 +1698,6 @@ final class Functions {
 	 * @return A function call for {@code e({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation e() {
 
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.E);
@@ -1825,8 +1711,7 @@ final class Functions {
 	 * @return A function call for {@code exp({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation exp(@NotNull Expression expression) {
+	static FunctionInvocation exp(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.EXP, expression);
@@ -1840,8 +1725,7 @@ final class Functions {
 	 * @return A function call for {@code log({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation log(@NotNull Expression expression) {
+	static FunctionInvocation log(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.LOG, expression);
@@ -1855,8 +1739,7 @@ final class Functions {
 	 * @return A function call for {@code log10({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation log10(@NotNull Expression expression) {
+	static FunctionInvocation log10(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.LOG10, expression);
@@ -1870,8 +1753,7 @@ final class Functions {
 	 * @return A function call for {@code sqrt({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation sqrt(@NotNull Expression expression) {
+	static FunctionInvocation sqrt(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.SQRT, expression);
@@ -1885,8 +1767,7 @@ final class Functions {
 	 * @return A function call for {@code acos({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation acos(@NotNull Expression expression) {
+	static FunctionInvocation acos(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.ACOS, expression);
@@ -1900,8 +1781,7 @@ final class Functions {
 	 * @return A function call for {@code asin({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation asin(@NotNull Expression expression) {
+	static FunctionInvocation asin(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.ASIN, expression);
@@ -1915,8 +1795,7 @@ final class Functions {
 	 * @return A function call for {@code atan({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation atan(@NotNull Expression expression) {
+	static FunctionInvocation atan(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.ATAN, expression);
@@ -1931,8 +1810,7 @@ final class Functions {
 	 * @return A function call for {@code atan2({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation atan2(@NotNull Expression y, @NotNull Expression x) {
+	static FunctionInvocation atan2(Expression y, Expression x) {
 
 		Assertions.notNull(y, "y is required.");
 		Assertions.notNull(x, "x is required.");
@@ -1947,8 +1825,7 @@ final class Functions {
 	 * @return A function call for {@code cos({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation cos(@NotNull Expression expression) {
+	static FunctionInvocation cos(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.COS, expression);
@@ -1962,8 +1839,7 @@ final class Functions {
 	 * @return A function call for {@code cot({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation cot(@NotNull Expression expression) {
+	static FunctionInvocation cot(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.COT, expression);
@@ -1977,8 +1853,7 @@ final class Functions {
 	 * @return A function call for {@code degrees({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation degrees(@NotNull Expression expression) {
+	static FunctionInvocation degrees(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.DEGREES, expression);
@@ -1992,8 +1867,7 @@ final class Functions {
 	 * @return A function call for {@code haversin({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation haversin(@NotNull Expression expression) {
+	static FunctionInvocation haversin(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.HAVERSIN, expression);
@@ -2006,7 +1880,6 @@ final class Functions {
 	 * @return A function call for {@code pi({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation pi() {
 
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.PI);
@@ -2020,8 +1893,7 @@ final class Functions {
 	 * @return A function call for {@code radians({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation radians(@NotNull Expression expression) {
+	static FunctionInvocation radians(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.RADIANS, expression);
@@ -2035,8 +1907,7 @@ final class Functions {
 	 * @return A function call for {@code sin({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation sin(@NotNull Expression expression) {
+	static FunctionInvocation sin(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.SIN, expression);
@@ -2050,8 +1921,7 @@ final class Functions {
 	 * @return A function call for {@code tan({})}.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation tan(@NotNull Expression expression) {
+	static FunctionInvocation tan(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(BuiltInFunctions.MathematicalFunctions.TAN, expression);
@@ -2065,8 +1935,7 @@ final class Functions {
 	 * @return A function call for {@code toInteger({})}.
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toInteger(@NotNull Expression expression) {
+	static FunctionInvocation toInteger(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Scalars.TO_INTEGER, expression);
@@ -2080,8 +1949,7 @@ final class Functions {
 	 * @return A function call for {@code toString({})}.
 	 * @since 2022.3.0
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toString(@NotNull Expression expression) {
+	static FunctionInvocation toString(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Scalars.TO_STRING, expression);
@@ -2095,8 +1963,7 @@ final class Functions {
 	 * @return A function call for {@code toStringOrNull({})}.
 	 * @since 2023.0.2
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toStringOrNull(@NotNull Expression expression) {
+	static FunctionInvocation toStringOrNull(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Strings.TO_STRING_OR_NULL, expressionOrNullLit(expression));
@@ -2110,8 +1977,7 @@ final class Functions {
 	 * @return A function call for {@code toFloat({})}.
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toFloat(@NotNull Expression expression) {
+	static FunctionInvocation toFloat(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Scalars.TO_FLOAT, expression);
@@ -2125,8 +1991,7 @@ final class Functions {
 	 * @return A function call for {@code toBoolean({})}.
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation toBoolean(@NotNull Expression expression) {
+	static FunctionInvocation toBoolean(Expression expression) {
 
 		Assertions.notNull(expression, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSION_REQUIRED));
 		return FunctionInvocation.create(Scalars.TO_BOOLEAN, expression);
@@ -2138,7 +2003,6 @@ final class Functions {
 	 * @return A function call for {@code linenumber({})}.
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation linenumber() {
 
 		return FunctionInvocation.create(() -> "linenumber");
@@ -2150,7 +2014,6 @@ final class Functions {
 	 * @return A function call for {@code file({})}.
 	 * @since 2021.2.1
 	 */
-	@NotNull @Contract(pure = true)
 	static FunctionInvocation file() {
 
 		return FunctionInvocation.create(() -> "file");
@@ -2174,8 +2037,7 @@ final class Functions {
 	 * @return A function call for {@code length()} on a path.
 	 * @since 2023.0.1
 	 */
-	@NotNull @Contract(pure = true)
-	static FunctionInvocation length(@NotNull NamedPath path) {
+	static FunctionInvocation length(NamedPath path) {
 
 		Assertions.notNull(path, "The path for length is required.");
 		return FunctionInvocation.create(Scalars.LENGTH,
@@ -2190,8 +2052,6 @@ final class Functions {
 	 * @return A function call for {@code graph.names()}.
 	 * @since 2023.4.0
 	 */
-	@NotNull
-	@Contract(pure = true)
 	@Neo4jVersion(minimum = "5.0.0")
 	static FunctionInvocation graphNames() {
 
@@ -2206,8 +2066,6 @@ final class Functions {
 	 * @return A function call for {@code graph.propertiesByName()}.
 	 * @since 2023.4.0
 	 */
-	@NotNull
-	@Contract(pure = true)
 	@Neo4jVersion(minimum = "5.0.0")
 	static FunctionInvocation graphPropertiesByName(Expression name) {
 
@@ -2222,8 +2080,6 @@ final class Functions {
 	 * @return A function call for {@code graph.byName()}.
 	 * @since 2023.4.0
 	 */
-	@NotNull
-	@Contract(pure = true)
 	@Neo4jVersion(minimum = "5.0.0")
 	static FunctionInvocation graphByName(Expression name) {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableElement.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This interface represents an element that can be for example an identifiable part of the {@code WITH} clause.
@@ -42,6 +40,5 @@ public sealed interface IdentifiableElement permits AliasedExpression, Asterisk,
 	 * @return this element as an expression. Will return the same instance if it is already an expression.
 	 * @since 2021.2.2
 	 */
-	@NotNull @Contract(pure = true)
 	Expression asExpression();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ImportingWith.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ImportingWith.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -39,13 +38,12 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 2023.1.0
  */
 @API(status = INTERNAL, since = "2023.1.0")
-record ImportingWith(@Nullable With imports, @Nullable With renames) implements Visitable {
+record ImportingWith(With imports, With renames) implements Visitable {
 
 	ImportingWith() {
 		this(null, null);
 	}
 
-	@Nullable
 	static ImportingWith of(IdentifiableElement... imports) {
 
 		With optionalImports;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InTransactions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InTransactions.java
@@ -22,7 +22,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -38,11 +37,10 @@ public final class InTransactions implements Visitable {
 
 	private final Subquery subquery;
 
-	@Nullable
 	private final Integer rows;
 
 	@API(status = INTERNAL)
-	InTransactions(Subquery subquery, @Nullable Integer rows) {
+	InTransactions(Subquery subquery, Integer rows) {
 		this.subquery = subquery;
 		this.rows = rows;
 	}
@@ -51,7 +49,6 @@ public final class InTransactions implements Visitable {
 	 * @return number of rows in this transaction
 	 */
 	@API(status = INTERNAL)
-	@Nullable
 	public Integer getRows() {
 		return rows;
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalNodeImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalNodeImpl.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
 /**
@@ -58,7 +56,6 @@ final class InternalNodeImpl extends NodeBase<InternalNodeImpl> {
 		super(symbolicName, primaryLabel, properties, additionalLabels);
 	}
 
-	@NotNull
 	@Override
 	public InternalNodeImpl named(SymbolicName newSymbolicName) {
 
@@ -67,16 +64,14 @@ final class InternalNodeImpl extends NodeBase<InternalNodeImpl> {
 
 	}
 
-	@NotNull
 	@Override
 	public InternalNodeImpl withProperties(MapExpression newProperties) {
 
 		return new InternalNodeImpl(this.getSymbolicName().orElse(null), labels, labelExpression, Properties.create(newProperties), innerPredicate);
 	}
 
-	@NotNull
 	@Override
-	public Node where(@Nullable Expression predicate) {
+	public Node where(Expression predicate) {
 		if (predicate == null) {
 			return this;
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalPropertyImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalPropertyImpl.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -95,7 +94,6 @@ final class InternalPropertyImpl implements Property {
 		this.externalReference = externalReference;
 	}
 
-	@NotNull
 	@Override
 	public List<PropertyLookup> getNames() {
 		return names;
@@ -106,13 +104,11 @@ final class InternalPropertyImpl implements Property {
 		return container;
 	}
 
-	@NotNull
 	@Override
 	public Expression getContainerReference() {
 		return containerReference;
 	}
 
-	@NotNull
 	@Override
 	public String getName() {
 		return externalReference != null ?
@@ -122,7 +118,6 @@ final class InternalPropertyImpl implements Property {
 				.collect(Collectors.joining("."));
 	}
 
-	@NotNull
 	@Override
 	public Property referencedAs(String newReference) {
 
@@ -130,7 +125,6 @@ final class InternalPropertyImpl implements Property {
 			newReference);
 	}
 
-	@NotNull
 	@Override
 	public Operation to(Expression expression) {
 		return Operations.set(this, expression);
@@ -166,7 +160,6 @@ final class InternalPropertyImpl implements Property {
 	}
 
 	@Override
-	@NotNull
 	public Expression asExpression() {
 		return this;
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalRelationshipImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalRelationshipImpl.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An internal implementation of the {@link RelationshipBase}. It's primary purpose is to have {@link RelationshipBase#named(SymbolicName)}
@@ -48,14 +47,12 @@ final class InternalRelationshipImpl extends RelationshipBase<NodeBase<?>, NodeB
 		super(left, details, quantifier, right);
 	}
 
-	@NotNull
 	@Override
 	public InternalRelationshipImpl named(SymbolicName newSymbolicName) {
 
 		return new InternalRelationshipImpl(this.left, this.details.named(newSymbolicName), quantifier, this.right);
 	}
 
-	@NotNull
 	@Override
 	public InternalRelationshipImpl withProperties(MapExpression newProperties) {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
@@ -22,7 +22,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -49,9 +48,8 @@ public final class KeyValueMapEntry implements Expression {
 	 * @return A new, immutable map entry.
 	 * @since 2021.2.3
 	 */
-	@NotNull
 	@API(status = STABLE, since = "2021.2.3")
-	public static KeyValueMapEntry create(@NotNull String key, @NotNull Expression value) {
+	public static KeyValueMapEntry create(String key, Expression value) {
 
 		Assertions.notNull(key, "Key is required.");
 		Assertions.notNull(value, "Value is required.");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListComprehension.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListComprehension.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
@@ -78,7 +76,7 @@ public final class ListComprehension implements Expression {
 		 * @param list The source list.
 		 * @return An ongoing definition
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingDefinitionWithList in(Expression list);
 	}
 
@@ -93,7 +91,7 @@ public final class ListComprehension implements Expression {
 		 * @param condition the condition to start the {@code WHERE} clause with.
 		 * @return An ongoing definition
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingDefinitionWithoutReturn where(Condition condition);
 	}
 
@@ -107,7 +105,6 @@ public final class ListComprehension implements Expression {
 		 * @return The final definition of the list comprehension
 		 * @see #returning(Expression...)
 		 */
-		@NotNull @Contract(pure = true)
 		default ListComprehension returning(Named... variables) {
 			return returning(Expressions.createSymbolicNames(variables));
 		}
@@ -116,14 +113,12 @@ public final class ListComprehension implements Expression {
 		 * @param listDefinition Defines the elements to be returned from the pattern
 		 * @return The final definition of the list comprehension
 		 */
-		@NotNull @Contract(pure = true)
 		ListComprehension returning(Expression... listDefinition);
 
 		/**
 		 * @return Returns the list comprehension as is, without a {@literal WHERE} and returning each element of the
 		 * original list
 		 */
-		@NotNull @Contract(pure = true)
 		ListComprehension returning();
 	}
 
@@ -138,29 +133,25 @@ public final class ListComprehension implements Expression {
 			this.variable = variable;
 		}
 
-		@NotNull
 		@Override
 		public OngoingDefinitionWithList in(Expression list) {
 			this.listExpression = list;
 			return this;
 		}
 
-		@NotNull
 		@Override
 		public OngoingDefinitionWithoutReturn where(Condition condition) {
 			this.where = new Where(condition);
 			return this;
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public ListComprehension returning() {
 
 			return new ListComprehension(variable, listExpression, where, null);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public ListComprehension returning(Expression... expressions) {
 
 			return new ListComprehension(variable, listExpression, where,

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListLiteral.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A list of literals.
@@ -40,7 +39,6 @@ public final class ListLiteral extends LiteralBase<Iterable<Literal<?>>> {
 		super(content);
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
@@ -23,7 +23,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.ProvidesAffixes;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
@@ -43,8 +42,7 @@ public final class ListOperator implements Expression, Visitable {
 	 * A literal for the dots.
 	 */
 	static final Literal<String> DOTS = new LiteralBase<>("..") {
-		@NotNull
-		@Override
+			@Override
 		public String asString() {
 			return content;
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Literal.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Literal.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a literal with an optional content.
@@ -41,7 +39,6 @@ public interface Literal<T> extends Expression {
 	 *
 	 * @return A string representation to be used literally in a cypher statement.
 	 */
-	@NotNull @Contract(pure = true)
 	String asString();
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/LoadCSVStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/LoadCSVStatementBuilder.java
@@ -23,9 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.net.URI;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.DefaultLoadCSVStatementBuilder.PrepareLoadCSVStatementImpl;
 
 /**
@@ -42,8 +39,7 @@ public interface LoadCSVStatementBuilder extends StatementBuilder {
 	 * @param rate The rate to be used. No checks are done on the rate, the database will verify valid values.
 	 * @return An ongoing definition of a {@code LOAD CSV} clause
 	 */
-	@NotNull @Contract(pure = true)
-	static ExposesLoadCSV usingPeriodicCommit(@Nullable Integer rate) {
+	static ExposesLoadCSV usingPeriodicCommit(Integer rate) {
 		return new PrepareLoadCSVStatementImpl(rate);
 	}
 
@@ -54,7 +50,6 @@ public interface LoadCSVStatementBuilder extends StatementBuilder {
 	 * @param withHeaders Set to {@literal true} if the csv file contains header
 	 * @return An ongoing definition of a {@code LOAD CSV} clause
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingLoadCSV loadCSV(URI from, boolean withHeaders) {
 		return new PrepareLoadCSVStatementImpl(from, withHeaders);
 	}
@@ -70,7 +65,6 @@ public interface LoadCSVStatementBuilder extends StatementBuilder {
 		 * @param alias The alias for each line
 		 * @return A statement builder supporting all available clauses plus an option to configure the field terminator
 		 */
-		@NotNull @Contract(pure = true)
 		default LoadCSVStatementBuilder as(SymbolicName alias) {
 			return as(alias.getValue());
 		}
@@ -81,7 +75,6 @@ public interface LoadCSVStatementBuilder extends StatementBuilder {
 		 * @param alias The alias for each line
 		 * @return A statement builder supporting all available clauses plus an option to configure the field terminator
 		 */
-		@NotNull @Contract(pure = true)
 		LoadCSVStatementBuilder as(String alias);
 	}
 
@@ -91,6 +84,5 @@ public interface LoadCSVStatementBuilder extends StatementBuilder {
 	 * @param fieldTerminator A new field terminator
 	 * @return A statement builder supporting all available clauses
 	 */
-	@NotNull @Contract(pure = true)
 	StatementBuilder withFieldTerminator(String fieldTerminator);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapLiteral.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A map of literals.
@@ -39,7 +38,6 @@ public final class MapLiteral extends LiteralBase<Map<String, Literal<?>>> {
 		super(content);
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 		return content.entrySet().stream()

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -81,7 +79,6 @@ public final class MapProjection implements Expression {
 	 * @param content The additional content for a new projection.
 	 * @return A new map projection with additional content.
 	 */
-	@NotNull @Contract(pure = true)
 	public MapProjection and(Object... content) {
 		return new MapProjection(this.name, this.map.addEntries(createNewContent(false, content)));
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -50,7 +49,7 @@ public final class Match extends AbstractClause implements ReadingClause {
 
 	private final Where optionalWhere;
 
-	Match(boolean optional, Pattern pattern, @Nullable Where optionalWhere, @Nullable List<Hint> optionalHints) {
+	Match(boolean optional, Pattern pattern, Where optionalWhere, List<Hint> optionalHints) {
 		this.optional = optional;
 		this.pattern = pattern;
 		this.optionalWhere = optionalWhere;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A named thing exposes {@link #getSymbolicName()}, making the thing identifiable.
@@ -38,20 +36,17 @@ public non-sealed interface Named extends IdentifiableElement {
 	/**
 	 * @return An optional symbolic name.
 	 */
-	@NotNull @Contract(pure = true)
 	Optional<SymbolicName> getSymbolicName();
 
 	/**
 	 * @return A symbolic name
 	 * @throws IllegalStateException If this has not been named yet.
 	 */
-	@NotNull @Contract(pure = true)
 	default SymbolicName getRequiredSymbolicName() {
 		return getSymbolicName().orElseThrow(() -> new IllegalStateException("No name present."));
 	}
 
-	@Override @NotNull
-	default Expression asExpression() {
+	@Override default Expression asExpression() {
 		return getRequiredSymbolicName();
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -24,8 +24,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.FunctionInvocation.FunctionDefinition;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
@@ -120,7 +118,6 @@ public final class NamedPath implements PatternElement, Named {
 		 * @param pattern The pattern to be matched for the named path.
 		 * @return A named path.
 		 */
-		@NotNull @Contract(pure = true)
 		NamedPath definedBy(PatternElement pattern);
 	}
 
@@ -136,7 +133,6 @@ public final class NamedPath implements PatternElement, Named {
 		 * @return A named path.
 		 * @since 2020.1.4
 		 */
-		@NotNull @Contract(pure = true)
 		NamedPath get();
 	}
 
@@ -168,8 +164,7 @@ public final class NamedPath implements PatternElement, Named {
 
 	private record Builder(SymbolicName name) implements OngoingDefinitionWithName {
 
-		@NotNull
-		@Override
+			@Override
 		public NamedPath definedBy(PatternElement pattern) {
 			if (pattern instanceof NamedPath namedPath) {
 				return namedPath;
@@ -177,8 +172,7 @@ public final class NamedPath implements PatternElement, Named {
 			return new NamedPath(name, null, pattern);
 		}
 
-		@NotNull
-		@Override
+			@Override
 		public NamedPath get() {
 			return new NamedPath(name);
 		}
@@ -210,8 +204,7 @@ public final class NamedPath implements PatternElement, Named {
 		}
 
 		@Override
-		@NotNull
-		public  NamedPath definedBy(PatternElement pattern) {
+			public  NamedPath definedBy(PatternElement pattern) {
 			return new NamedPath(name, shortest, pattern);
 		}
 
@@ -236,7 +229,6 @@ public final class NamedPath implements PatternElement, Named {
 	}
 
 	@Override
-	@NotNull
 	public Optional<SymbolicName> getSymbolicName() {
 		return Optional.of(name);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M15/railroad/NodePattern.html">NodePattern</a>.
@@ -38,7 +36,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	/**
 	 * @return The labels associated with this {@link Node}
 	 */
-	@NotNull @Contract(pure = true)
 	List<NodeLabel> getLabels();
 
 	/**
@@ -47,7 +44,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @param newSymbolicName the new symbolic name.
 	 * @return The new node.
 	 */
-	@NotNull @Contract(pure = true)
 	Node named(String newSymbolicName);
 
 	/**
@@ -56,7 +52,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @param newSymbolicName the new symbolic name.
 	 * @return The new node.
 	 */
-	@NotNull @Contract(pure = true)
 	Node named(SymbolicName newSymbolicName);
 
 	/**
@@ -65,14 +60,12 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @param labelsToQuery A list of labels to query
 	 * @return A condition that checks whether this node has all the labels to query
 	 */
-	@NotNull @Contract(pure = true)
 	Condition hasLabels(String... labelsToQuery);
 
 	/**
 	 * A condition that checks for the presence of a label expression on a node
 	 * @since 2024.3.0
 	 */
-	@NotNull @Contract(pure = true)
 	Condition hasLabels(LabelExpression labels);
 
 	/**
@@ -81,7 +74,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @param otherNode The node to compare this node to.
 	 * @return A condition.
 	 */
-	@NotNull @Contract(pure = true)
 	Condition isEqualTo(Node otherNode);
 
 	/**
@@ -90,7 +82,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @param otherNode The node to compare this node to.
 	 * @return A condition.
 	 */
-	@NotNull @Contract(pure = true)
 	Condition isNotEqualTo(Node otherNode);
 
 	/**
@@ -98,7 +89,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 *
 	 * @return A condition.
 	 */
-	@NotNull @Contract(pure = true)
 	Condition isNull();
 
 	/**
@@ -106,7 +96,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 *
 	 * @return A condition.
 	 */
-	@NotNull @Contract(pure = true)
 	Condition isNotNull();
 
 	/**
@@ -114,7 +103,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 *
 	 * @return A sort item.
 	 */
-	@NotNull @Contract(pure = true)
 	SortItem descending();
 
 	/**
@@ -122,7 +110,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 *
 	 * @return A sort item.
 	 */
-	@NotNull @Contract(pure = true)
 	SortItem ascending();
 
 	/**
@@ -131,14 +118,12 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @param alias The alias to use.
 	 * @return The aliased expression.
 	 */
-	@NotNull @Contract(pure = true)
 	AliasedExpression as(String alias);
 
 	/**
 	 * @return A new function invocation returning the internal id of this node.
 	 * @deprecated Use {@link #elementId}
 	 */
-	@NotNull @Contract(pure = true)
 	@Deprecated(since = "2022.6.0")
 	@SuppressWarnings({ "DeprecatedIsStillUsed", "squid:S1133" }) // The deprecation warning on any client code calling this is actually the point.
 	FunctionInvocation internalId();
@@ -147,7 +132,6 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 * @return A new function invocation returning the element id of this node.
 	 * @since 2022.6.0
 	 */
-	@NotNull @Contract(pure = true)
 	default FunctionInvocation elementId() {
 		return Functions.elementId(this);
 	}
@@ -155,6 +139,5 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	/**
 	 * @return A new function invocation returning the labels of this node.
 	 */
-	@NotNull @Contract(pure = true)
 	FunctionInvocation labels();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
@@ -97,12 +96,10 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	 * @return A new node
 	 */
 	@Override
-	@NotNull
 	@SuppressWarnings("squid:S3038") // This is overridden to make sure we allow a covariant return type
 	public abstract SELF named(SymbolicName newSymbolicName);
 
 	@Override
-	@NotNull
 	public final SELF withProperties(Object... keysAndValues) {
 
 		MapExpression newProperties = null;
@@ -119,7 +116,6 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	 * @return A new object
 	 */
 	@Override
-	@NotNull
 	public final SELF withProperties(Map<String, Object> newProperties) {
 
 		return withProperties(MapExpression.create(newProperties));
@@ -132,7 +128,6 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	 */
 	@Override
 	@SuppressWarnings("squid:S3038") // This is overridden to make sure we allow a covariant return type
-	@NotNull
 	public abstract SELF withProperties(MapExpression newProperties);
 
 	/**
@@ -143,19 +138,16 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	}
 
 	@Override
-	@NotNull
 	public final List<NodeLabel> getLabels() {
 		return labels == null ? List.of() : List.copyOf(labels);
 	}
 
 	@Override
-	@NotNull
 	public final Optional<SymbolicName> getSymbolicName() {
 		return Optional.ofNullable(symbolicName);
 	}
 
 	@Override
-	@NotNull
 	public final SymbolicName getRequiredSymbolicName() {
 
 		SymbolicName requiredSymbolicName = this.symbolicName;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/OngoingListBasedPredicateFunction.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/OngoingListBasedPredicateFunction.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
@@ -33,7 +32,6 @@ public interface OngoingListBasedPredicateFunction {
 	 * @param list A list expression
 	 * @return A builder to specify the where condition for the list based predicate
 	 */
-	@NotNull
 	@CheckReturnValue
 	OngoingListBasedPredicateFunctionWithList in(Expression list);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/OngoingListBasedPredicateFunctionWithList.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/OngoingListBasedPredicateFunctionWithList.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Allows to specify the where condition for the list based predicate.
@@ -33,7 +31,5 @@ public interface OngoingListBasedPredicateFunctionWithList {
 	 * @param condition The condition for the list based predicate.
 	 * @return The final list based predicate function
 	 */
-	@NotNull
-	@Contract(pure = true)
 	Condition where(Condition condition);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
@@ -26,7 +26,6 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
@@ -48,7 +47,7 @@ public final class Operation implements Expression {
 		.complementOf(EnumSet.of(Operator.Type.PROPERTY, Operator.Type.LABEL));
 	private static final EnumSet<Operator> DONT_GROUP = EnumSet.of(Operator.EXPONENTIATION, Operator.PIPE, Operator.UNARY_MINUS, Operator.UNARY_PLUS);
 
-	static Operation create(@NotNull Operator operator, @NotNull Expression expression) {
+	static Operation create(Operator operator, Expression expression) {
 
 		Assertions.notNull(operator, "Operator must not be null.");
 		Assertions.isTrue(operator.isUnary(), "Operator must be unary.");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternComprehension.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternComprehension.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
@@ -61,7 +59,6 @@ public final class PatternComprehension implements Expression {
 		 * @return The final definition of the pattern comprehension
 		 * @see #returning(Expression...)
 		 */
-		@NotNull @Contract(pure = true)
 		default PatternComprehension returning(Named... variables) {
 			return returning(Expressions.createSymbolicNames(variables));
 		}
@@ -70,7 +67,6 @@ public final class PatternComprehension implements Expression {
 		 * @param listDefinition Defines the elements to be returned from the pattern
 		 * @return The final definition of the pattern comprehension
 		 */
-		@NotNull @Contract(pure = true)
 		PatternComprehension returning(Expression... listDefinition);
 	}
 
@@ -85,7 +81,7 @@ public final class PatternComprehension implements Expression {
 		 * @param condition An initial condition to be used with {@code WHERE}
 		 * @return An ongoing definition of a pattern comprehension for furhter modification
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingDefinitionWithPatternAndWhere where(Condition condition);
 
 		/**
@@ -97,7 +93,7 @@ public final class PatternComprehension implements Expression {
 		 * @return A match or a call restricted by a where clause with no return items yet.
 		 * @since 2020.1.4
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default OngoingDefinitionWithPatternAndWhere where(RelationshipPattern pathPattern) {
 
 			Assertions.notNull(pathPattern, "The path pattern must not be null.");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternElement.java
@@ -21,9 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 
 /**
@@ -49,8 +46,7 @@ public interface PatternElement extends Visitable {
 	 * @since 2023.9.0
 	 */
 	@Neo4jVersion(minimum = "5.0")
-	@NotNull @Contract(pure = true)
-	default PatternElement where(@Nullable Expression predicate) {
+	default PatternElement where(Expression predicate) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PeriodLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PeriodLiteral.java
@@ -20,7 +20,6 @@ package org.neo4j.cypherdsl.core;
 
 import java.time.Period;
 
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A literal representing a period value to be formatted in a way that Neo4j's Cypher understands it.
@@ -44,7 +43,6 @@ final class PeriodLiteral extends LiteralBase<Period> {
 	}
 
 	@Override
-	@NotNull
 	public String asString() {
 		var result = new StringBuilder();
 		result.append("duration('P");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
@@ -20,9 +20,6 @@ package org.neo4j.cypherdsl.core;
 
 import java.util.List;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
 /**
@@ -42,7 +39,6 @@ final class Predicates {
 	 * @param property The property to be passed to {@code exists()}
 	 * @return A function call for {@code exists()} for one property
 	 */
-	@NotNull @Contract(pure = true)
 	static Condition exists(Property property) {
 
 		return new BooleanFunctionCondition(FunctionInvocation.create(BuiltInFunctions.Predicates.EXISTS, property));
@@ -55,7 +51,6 @@ final class Predicates {
 	 * @param pattern The pattern to be passed to {@code exists()}
 	 * @return A function call for {@code exists()} for one pattern
 	 */
-	@NotNull @Contract(pure = true)
 	static Condition exists(RelationshipPattern pattern) {
 
 		return new BooleanFunctionCondition(FunctionInvocation.create(BuiltInFunctions.Predicates.EXISTS, pattern));
@@ -119,7 +114,7 @@ final class Predicates {
 	 * @return An existential sub-query.
 	 * @since 2023.9.0
 	 */
-	static Condition exists(List<PatternElement> pattern, @Nullable Where where) {
+	static Condition exists(List<PatternElement> pattern, Where where) {
 
 		return ExistentialSubquery.exists(pattern, where);
 	}
@@ -130,7 +125,6 @@ final class Predicates {
 	 * @see #all(SymbolicName)
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction all(String variable) {
 
 		return all(SymbolicName.of(variable));
@@ -144,7 +138,6 @@ final class Predicates {
 	 * @return A builder for the {@code all()} predicate function
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction all(SymbolicName variable) {
 
 		return new Builder(BuiltInFunctions.Predicates.ALL, variable);
@@ -156,7 +149,6 @@ final class Predicates {
 	 * @see #any(SymbolicName)
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction any(String variable) {
 
 		return any(SymbolicName.of(variable));
@@ -170,7 +162,6 @@ final class Predicates {
 	 * @return A builder for the {@code any()} predicate function
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction any(SymbolicName variable) {
 
 		return new Builder(BuiltInFunctions.Predicates.ANY, variable);
@@ -182,7 +173,6 @@ final class Predicates {
 	 * @see #none(SymbolicName)
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction none(String variable) {
 
 		return none(SymbolicName.of(variable));
@@ -196,7 +186,6 @@ final class Predicates {
 	 * @return A builder for the {@code none()} predicate function
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction none(SymbolicName variable) {
 
 		return new Builder(BuiltInFunctions.Predicates.NONE, variable);
@@ -208,7 +197,6 @@ final class Predicates {
 	 * @see #single(SymbolicName)
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction single(String variable) {
 
 		return single(SymbolicName.of(variable));
@@ -222,7 +210,6 @@ final class Predicates {
 	 * @return A builder for the {@code single()} predicate function
 	 * @since 1.1
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingListBasedPredicateFunction single(SymbolicName variable) {
 
 		return new Builder(BuiltInFunctions.Predicates.SINGLE, variable);
@@ -258,16 +245,14 @@ final class Predicates {
 			this.name = name;
 		}
 
-		@Override @NotNull
-		public OngoingListBasedPredicateFunctionWithList in(Expression list) {
+		@Override 	public OngoingListBasedPredicateFunctionWithList in(Expression list) {
 
 			Assertions.notNull(list, "The list expression is required");
 			this.listExpression = list;
 			return this;
 		}
 
-		@Override @NotNull
-		public Condition where(Condition condition) {
+		@Override 	public Condition where(Condition condition) {
 
 			Assertions.notNull(condition, "The condition is required");
 			return new BooleanFunctionCondition(

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -43,7 +42,6 @@ public final class Properties implements Visitable {
 	 * @param expression Nullable expression
 	 * @return A properties expression
 	 */
-	@Contract(pure = true)
 	public static Properties create(MapExpression expression) {
 
 		return expression == null ? null : new Properties(expression);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
@@ -24,8 +24,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A property. A property might belong to a container such as a {@link Node} or {@link Relationship}, but it's not uncommon
@@ -46,27 +44,22 @@ public non-sealed interface Property extends Expression, IdentifiableElement {
 	 * @return A name to reference the property under in an external application
 	 */
 	@API(status = STABLE, since = "2021.1.0")
-	@NotNull @Contract(pure = true)
 	String getName();
 
 	/**
 	 * @return The actual property being looked up. The order matters, so this will return a list, not a collection.
 	 */
-	@NotNull @Contract(pure = true)
 	List<PropertyLookup> getNames();
 
 	/**
 	 * @return The container "owning" this property.
 	 */
-	@Contract(pure = true)
 	Named getContainer();
 
 	/**
 	 * @return A reference to the container owning this property
 	 */
 	@API(status = INTERNAL, since = "2023.1.0")
-	@NotNull
-	@Contract(pure = true)
 	default Expression getContainerReference() {
 		if (getContainer() == null) {
 			throw new UnsupportedOperationException();
@@ -81,7 +74,6 @@ public non-sealed interface Property extends Expression, IdentifiableElement {
 	 * @return A new property
 	 */
 	@API(status = STABLE, since = "2021.1.0")
-	@NotNull @Contract(pure = true)
 	Property referencedAs(String newReference);
 
 	/**
@@ -91,6 +83,5 @@ public non-sealed interface Property extends Expression, IdentifiableElement {
 	 * @param expression expression describing the new value
 	 * @return A new operation.
 	 */
-	@NotNull @Contract(pure = true)
 	Operation to(Expression expression);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyAccessor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyAccessor.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This interface represents an element that has properties.
@@ -44,8 +42,7 @@ public interface PropertyAccessor {
 	 * @param name property name, must not be {@literal null} or empty.
 	 * @return a new {@link Property} associated with this element
 	 */
-	@NotNull @Contract(pure = true)
-	default Property property(@NotNull String name) {
+	default Property property(String name) {
 		return property(new String[] { name });
 	}
 
@@ -54,7 +51,6 @@ public interface PropertyAccessor {
 	 * @return a new {@link Property} associated with this element
 	 * @see  #property(String)
 	 */
-	@NotNull @Contract(pure = true)
 	Property property(String... names);
 
 	/**
@@ -71,6 +67,5 @@ public interface PropertyAccessor {
 	 * @param lookup the expression that is evaluated to lookup this property.
 	 * @return a new {@link Property} associated with this element
 	 */
-	@NotNull @Contract(pure = true)
-	Property property(@NotNull Expression lookup);
+	Property property(Expression lookup);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A container having properties. A property container must be {@link Named} with a non empty name to be able to refer
@@ -45,7 +43,6 @@ public interface PropertyContainer extends Named, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 2020.1.5
 	 */
-	@NotNull @Contract(pure = true)
 	Operation mutate(Parameter<?> parameter);
 
 	/**
@@ -56,7 +53,6 @@ public interface PropertyContainer extends Named, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 2020.1.5
 	 */
-	@NotNull @Contract(pure = true)
 	Operation mutate(MapExpression properties);
 
 	/**
@@ -67,7 +63,6 @@ public interface PropertyContainer extends Named, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 2022.5.0
 	 */
-	@NotNull @Contract(pure = true)
 	Operation set(Parameter<?> parameter);
 
 	/**
@@ -78,7 +73,6 @@ public interface PropertyContainer extends Named, PropertyAccessor {
 	 * @return A new operation.
 	 * @since 2022.5.0
 	 */
-	@NotNull @Contract(pure = true)
 	Operation set(MapExpression properties);
 
 	/**
@@ -88,7 +82,6 @@ public interface PropertyContainer extends Named, PropertyAccessor {
 	 * @return A map projection.
 	 * @see SymbolicName#project(List)
 	 */
-	@NotNull @Contract(pure = true)
 	MapProjection project(List<Object> entries);
 
 	/**
@@ -98,6 +91,5 @@ public interface PropertyContainer extends Named, PropertyAccessor {
 	 * @return A map projection.
 	 * @see SymbolicName#project(Object...)
 	 */
-	@NotNull @Contract(pure = true)
 	MapProjection project(Object... entries);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/QuantifiedPathPattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/QuantifiedPathPattern.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -71,7 +69,7 @@ public final class QuantifiedPathPattern implements PatternElement {
 
 	private final Quantifier quantifier;
 
-	static QuantifiedPathPattern of(PatternElement patternElement, @Nullable Quantifier quantifier) {
+	static QuantifiedPathPattern of(PatternElement patternElement, Quantifier quantifier) {
 
 		var delegate = patternElement instanceof TargetPattern ppp ? ppp : new TargetPattern(patternElement, null);
 
@@ -92,7 +90,7 @@ public final class QuantifiedPathPattern implements PatternElement {
 	}
 
 	@Override
-	public @NotNull PatternElement where(@Nullable Expression predicate) {
+	public PatternElement where(Expression predicate) {
 		if (predicate == null) {
 			return this;
 		}
@@ -107,10 +105,9 @@ public final class QuantifiedPathPattern implements PatternElement {
 
 		private final PatternElement delegate;
 
-		@Nullable
-		private final Where innerPredicate;
+			private final Where innerPredicate;
 
-		private TargetPattern(PatternElement delegate, @Nullable Where innerPredicate) {
+		private TargetPattern(PatternElement delegate, Where innerPredicate) {
 			this.delegate = delegate;
 			this.innerPredicate = innerPredicate;
 		}
@@ -125,7 +122,7 @@ public final class QuantifiedPathPattern implements PatternElement {
 		}
 
 		@Override
-		public @NotNull PatternElement where(@Nullable Expression predicate) {
+		public PatternElement where(Expression predicate) {
 			if (predicate == null) {
 				return this;
 			}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/QueryDSLAdapter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/QueryDSLAdapter.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.build.annotations.RegisterForReflection;
 import org.neo4j.cypherdsl.core.querydsl.CypherContext;
 import org.neo4j.cypherdsl.core.querydsl.ToCypherFormatStringVisitor;
@@ -52,7 +51,6 @@ final class QueryDSLAdapter implements ForeignAdapter<com.querydsl.core.types.Ex
 	}
 
 	@Override
-	@NotNull
 	public Condition asCondition() {
 
 		if (!(expression instanceof Predicate)) {
@@ -70,7 +68,6 @@ final class QueryDSLAdapter implements ForeignAdapter<com.querydsl.core.types.Ex
 	}
 
 	@Override
-	@NotNull
 	public Expression asExpression() {
 
 		CypherContext context = new CypherContext();
@@ -80,7 +77,6 @@ final class QueryDSLAdapter implements ForeignAdapter<com.querydsl.core.types.Ex
 	}
 
 	@Override
-	@NotNull
 	public Node asNode() {
 
 		if (!(expression instanceof Path<?> entityPath)) {
@@ -90,7 +86,6 @@ final class QueryDSLAdapter implements ForeignAdapter<com.querydsl.core.types.Ex
 		return Cypher.node(entityPath.getRoot().getType().getSimpleName()).named(entityPath.getMetadata().getName());
 	}
 
-	@NotNull
 	@Override
 	public Relationship asRelationship() {
 
@@ -98,7 +93,6 @@ final class QueryDSLAdapter implements ForeignAdapter<com.querydsl.core.types.Ex
 	}
 
 	@Override
-	@NotNull
 	public SymbolicName asName() {
 
 		if (!(expression instanceof Path<?> entityPath)) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RawLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RawLiteral.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -53,8 +52,7 @@ final class RawLiteral implements Expression {
 		}
 
 		@Override
-		@NotNull
-		public String asString() {
+			public String asString() {
 
 			return content;
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Reduction.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Reduction.java
@@ -21,8 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.ast.TypedSubtree;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
@@ -47,7 +45,6 @@ public final class Reduction extends TypedSubtree<Visitable> {
 	 * @param variable The closure will have a variable introduced in its context. We decide here which variable to use.
 	 * @return An ongoing definition
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingDefinitionWithVariable of(SymbolicName variable) {
 
 		Assertions.notNull(variable, "A variable is required");
@@ -67,7 +64,7 @@ public final class Reduction extends TypedSubtree<Visitable> {
 		 * @param list The list that is the subject of the reduction
 		 * @return An ongoing definition
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingDefinitionWithList in(Expression list);
 	}
 
@@ -80,7 +77,7 @@ public final class Reduction extends TypedSubtree<Visitable> {
 		 * @param mapper This expression will run once per value in the list, and produce the result value.
 		 * @return An ongoing definition
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingDefinitionWithReducer map(Expression mapper);
 	}
 
@@ -93,7 +90,7 @@ public final class Reduction extends TypedSubtree<Visitable> {
 		 * @param accumulator A variable that will hold the result and the partial results as the list is iterated.
 		 * @return An ongoing definition
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingDefinitionWithInitial accumulateOn(Expression accumulator);
 	}
 
@@ -106,7 +103,6 @@ public final class Reduction extends TypedSubtree<Visitable> {
 		 * @param initialValue An expression that runs once to give a starting value to the accumulator.
 		 * @return An ongoing definition
 		 */
-		@NotNull @Contract(pure = true)
 		FunctionInvocation withInitialValueOf(Expression initialValue);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
@@ -26,9 +26,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.internal.RelationshipLength;
 import org.neo4j.cypherdsl.core.internal.RelationshipTypes;
 import org.neo4j.cypherdsl.core.ast.Visitable;
@@ -277,19 +274,16 @@ public interface Relationship extends RelationshipPattern, PropertyContainer, Ex
 	 *
 	 * @return A wrapper around the details of this relationship.
 	 */
-	@NotNull @Contract(pure = true)
 	Details getDetails();
 
 	/**
 	 * @return the right-hand side of this relationship
 	 */
-	@NotNull @Contract(pure = true)
 	Node getRight();
 
 	/**
 	 * {@return the quantifier of this relationship if any}
 	 */
-	@Nullable @Contract(pure = true)
 	QuantifiedPathPattern.Quantifier getQuantifier();
 
 	/**
@@ -298,7 +292,6 @@ public interface Relationship extends RelationshipPattern, PropertyContainer, Ex
 	 * @param newSymbolicName the new symbolic name.
 	 * @return The new relationship.
 	 */
-	@NotNull @Contract(pure = true)
 	Relationship named(String newSymbolicName);
 
 	/**
@@ -307,7 +300,6 @@ public interface Relationship extends RelationshipPattern, PropertyContainer, Ex
 	 * @param newSymbolicName the new symbolic name.
 	 * @return The new relationship.
 	 */
-	@NotNull @Contract(pure = true)
 	Relationship named(SymbolicName newSymbolicName);
 
 	/**
@@ -318,6 +310,5 @@ public interface Relationship extends RelationshipPattern, PropertyContainer, Ex
 	 *
 	 * @return the new relationship
 	 */
-	@NotNull @Contract(pure = true)
 	Relationship inverse();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
@@ -51,7 +49,6 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 
 	final Details details;
 
-	@Nullable
 	final QuantifiedPathPattern.Quantifier quantifier;
 
 	// ------------------------------------------------------------------------
@@ -114,7 +111,6 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 		this(symbolicName, start, Direction.LTR, properties, null, end, type);
 	}
 
-	@NotNull
 	@Override
 	public final SELF named(String newSymbolicName) {
 
@@ -127,11 +123,9 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 	 * @param newSymbolicName the new symbolic name.
 	 * @return A new relationship
 	 */
-	@NotNull
 	@Override
 	public abstract SELF named(SymbolicName newSymbolicName);
 
-	@NotNull
 	@Override
 	public final SELF withProperties(Object... keysAndValues) {
 
@@ -142,7 +136,6 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 		return withProperties(newProperties);
 	}
 
-	@NotNull
 	@Override
 	public final SELF withProperties(Map<String, Object> newProperties) {
 
@@ -154,82 +147,69 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
 	 * @return A new relationship
 	 */
-	@NotNull
 	@Override
 	public abstract SELF withProperties(MapExpression newProperties);
 
-	@NotNull
 	@Override
 	public final Node getLeft() {
 		return left;
 	}
 
-	@NotNull
 	@Override
 	public final Node getRight() {
 		return right;
 	}
 
-	@Nullable
 	@Override
 	public final QuantifiedPathPattern.Quantifier getQuantifier() {
 		return quantifier;
 	}
 
-	@NotNull
 	@Override
 	public final Details getDetails() {
 		return details;
 	}
 
-	@NotNull
 	@Override
 	public final Relationship unbounded() {
 
 		return new InternalRelationshipImpl(this.left, this.details.unbounded(), this.quantifier, this.right);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship min(Integer minimum) {
 
 		return new InternalRelationshipImpl(this.left, this.details.min(minimum), this.quantifier, this.right);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship max(Integer maximum) {
 
 		return new InternalRelationshipImpl(this.left, this.details.max(maximum), this.quantifier, this.right);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship length(Integer minimum, Integer maximum) {
 
 		return new InternalRelationshipImpl(this.left, this.details.min(minimum).max(maximum), this.quantifier, this.right);
 	}
 
-	@NotNull
 	@Override
 	public final Relationship inverse() {
 
 		return new InternalRelationshipImpl(this.right, this.details.inverse(), this.quantifier, this.left);
 	}
 
-	@NotNull
 	@Override
 	public final Optional<SymbolicName> getSymbolicName() {
 		return details.getSymbolicName();
 	}
 
-	@NotNull
 	@Override
 	public final SymbolicName getRequiredSymbolicName() {
 		return details.getRequiredSymbolicName();
 	}
 
-	@NotNull
 	@Override
 	public final RelationshipChain relationshipTo(Node other, String... types) {
 		return RelationshipChain
@@ -237,7 +217,6 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 				.add(this.right.relationshipTo(other, types));
 	}
 
-	@NotNull
 	@Override
 	public final RelationshipChain relationshipFrom(Node other, String... types) {
 		return RelationshipChain
@@ -245,7 +224,6 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 				.add(this.right.relationshipFrom(other, types));
 	}
 
-	@NotNull
 	@Override
 	public final RelationshipChain relationshipBetween(Node other, String... types) {
 		return RelationshipChain
@@ -253,7 +231,6 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 				.add(this.right.relationshipBetween(other, types));
 	}
 
-	@NotNull
 	@Override
 	public final Condition asCondition() {
 		return RelationshipPatternCondition.of(this);
@@ -304,16 +281,15 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 	}
 
 	@Override
-	public @NotNull Relationship where(@Nullable Expression predicate) {
+	public Relationship where(Expression predicate) {
 		if (predicate == null) {
 			return this;
 		}
 		return new InternalRelationshipImpl(this.left, this.details.where(predicate), this.quantifier, this.right);
 	}
 
-	@NotNull
 	@Override
-	public RelationshipPattern quantifyRelationship(@Nullable QuantifiedPathPattern.Quantifier newQuantifier) {
+	public RelationshipPattern quantifyRelationship(QuantifiedPathPattern.Quantifier newQuantifier) {
 		if (newQuantifier == null) {
 			return this;
 		}
@@ -321,9 +297,8 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 		return new InternalRelationshipImpl(this.left, this.details, newQuantifier, this.right);
 	}
 
-	@NotNull
 	@Override
-	public QuantifiedPathPattern quantify(@Nullable QuantifiedPathPattern.Quantifier newQuantifier) {
+	public QuantifiedPathPattern quantify(QuantifiedPathPattern.Quantifier newQuantifier) {
 
 		return QuantifiedPathPattern.of(this, newQuantifier);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -24,9 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
@@ -78,19 +75,16 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 		return newChain;
 	}
 
-	@NotNull
 	@Override
 	public RelationshipChain relationshipTo(Node other, String... types) {
 		return this.add(this.relationships.getLast().getRight().relationshipTo(other, types));
 	}
 
-	@NotNull
 	@Override
 	public RelationshipChain relationshipFrom(Node other, String... types) {
 		return this.add(this.relationships.getLast().getRight().relationshipFrom(other, types));
 	}
 
-	@NotNull
 	@Override
 	public RelationshipChain relationshipBetween(Node other, String... types) {
 		return this.add(this.relationships.getLast().getRight().relationshipBetween(other, types));
@@ -102,7 +96,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @param newSymbolicName The new symbolic name to use
 	 * @return A new chain
 	 */
-	@NotNull
 	@Override
 	public RelationshipChain named(String newSymbolicName) {
 
@@ -117,7 +110,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @return A new chain
 	 * @since 2021.1.1
 	 */
-	@NotNull
 	@Override
 	public RelationshipChain named(SymbolicName newSymbolicName) {
 
@@ -125,9 +117,8 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 		return this.replaceLast(lastElement.named(newSymbolicName));
 	}
 
-	@NotNull
 	@Override
-	public RelationshipChain where(@Nullable Expression predicate) {
+	public RelationshipChain where(Expression predicate) {
 
 		if (predicate == null) {
 			return this;
@@ -137,9 +128,8 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 		return this.replaceLast((Relationship) lastElement.where(predicate));
 	}
 
-	@NotNull
 	@Override
-	public RelationshipPattern quantifyRelationship(@Nullable QuantifiedPathPattern.Quantifier quantifier) {
+	public RelationshipPattern quantifyRelationship(QuantifiedPathPattern.Quantifier quantifier) {
 
 		if (quantifier == null) {
 			return this;
@@ -149,9 +139,8 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 		return this.replaceLast((Relationship) lastElement.quantifyRelationship(quantifier));
 	}
 
-	@NotNull
 	@Override
-	public QuantifiedPathPattern quantify(@Nullable QuantifiedPathPattern.Quantifier newQuantifier) {
+	public QuantifiedPathPattern quantify(QuantifiedPathPattern.Quantifier newQuantifier) {
 
 		return QuantifiedPathPattern.of(this, newQuantifier);
 	}
@@ -162,7 +151,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @return A new chain
 	 * @since 1.1.1
 	 */
-	@NotNull @Contract(pure = true)
 	@Override
 	public RelationshipChain unbounded() {
 
@@ -176,7 +164,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @param minimum the new minimum
 	 * @return A new chain
 	 */
-	@NotNull @Contract(pure = true)
 	@Override
 	public RelationshipChain min(Integer minimum) {
 
@@ -190,7 +177,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @param maximum the new maximum
 	 * @return A new chain
 	 */
-	@NotNull @Contract(pure = true)
 	@Override
 	public RelationshipChain max(Integer maximum) {
 
@@ -205,7 +191,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @param maximum the new maximum
 	 * @return A new chain
 	 */
-	@NotNull @Contract(pure = true)
 	@Override
 	public RelationshipChain length(Integer minimum, Integer maximum) {
 
@@ -219,7 +204,6 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
 	 * @return A new chain
 	 */
-	@NotNull @Contract(pure = true)
 	public RelationshipChain properties(MapExpression newProperties) {
 
 		Relationship lastElement = this.relationships.getLast();
@@ -232,14 +216,12 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}.
 	 * @return A new chain
 	 */
-	@NotNull @Contract(pure = true)
 	public RelationshipChain properties(Object... keysAndValues) {
 
 		Relationship lastElement = this.relationships.getLast();
 		return this.replaceLast(lastElement.withProperties(keysAndValues));
 	}
 
-	@NotNull
 	@Override
 	public Condition asCondition() {
 		return RelationshipPatternCondition.of(this);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
@@ -21,9 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
@@ -45,7 +42,7 @@ public interface RelationshipPattern extends PatternElement, ExposesRelationship
 	 * @param name The name to be used.
 	 * @return A named relationship that can be chained with more relationship definitions.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	ExposesRelationships<RelationshipChain> named(String name);
 
 	/**
@@ -54,7 +51,7 @@ public interface RelationshipPattern extends PatternElement, ExposesRelationship
 	 * @param name The name to be used.
 	 * @return A named relationship that can be chained with more relationship definitions.
 	 */
-	@NotNull @CheckReturnValue
+	@CheckReturnValue
 	ExposesRelationships<RelationshipChain> named(SymbolicName name);
 
 	/**
@@ -64,7 +61,6 @@ public interface RelationshipPattern extends PatternElement, ExposesRelationship
 	 * @return A condition based on this pattern.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	Condition asCondition();
 
 	/**
@@ -74,8 +70,7 @@ public interface RelationshipPattern extends PatternElement, ExposesRelationship
 	 * @return a quantified relationship
 	 * @since 2023.9.0
 	 */
-	@NotNull @Contract(pure = true)
-	default PatternElement quantifyRelationship(@Nullable QuantifiedPathPattern.Quantifier quantifier) {
+	default PatternElement quantifyRelationship(QuantifiedPathPattern.Quantifier quantifier) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -86,8 +81,7 @@ public interface RelationshipPattern extends PatternElement, ExposesRelationship
 	 * @return a quantified path pattern
 	 * @since 2023.9.0
 	 */
-	@NotNull @Contract(pure = true)
-	default PatternElement quantify(@Nullable QuantifiedPathPattern.Quantifier quantifier) {
+	default PatternElement quantify(QuantifiedPathPattern.Quantifier quantifier) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
@@ -57,7 +55,6 @@ public final class SortItem implements Visitable {
 	 * Creates a new sort item from {@literal this} instance, setting the sort direction to ascending.
 	 * @return A new sort item.
 	 */
-	@NotNull @Contract(pure = true)
 	public SortItem ascending() {
 		return new SortItem(this.expression, Direction.ASC);
 	}
@@ -66,7 +63,6 @@ public final class SortItem implements Visitable {
 	 * Creates a new sort item from {@literal this} instance, setting the sort direction to descending.
 	 * @return A new sort item.
 	 */
-	@NotNull @Contract(pure = true)
 	public SortItem descending() {
 		return new SortItem(this.expression, Direction.DESC);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Statement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Statement.java
@@ -24,8 +24,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingStandaloneCallWithoutArguments;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.internal.LoadCSV;
@@ -49,7 +47,6 @@ public interface Statement extends Visitable {
 	/**
 	 * @return A new statement builder.
 	 */
-	@NotNull @Contract(pure = true)
 	static StatementBuilder builder() {
 
 		return new DefaultStatementBuilder();
@@ -63,8 +60,7 @@ public interface Statement extends Visitable {
 	 * @return A statement
 	 * @since 2021.3.0
 	 */
-	@NotNull
-	static Statement of(@NotNull List<Clause> clauses) {
+	static Statement of(List<Clause> clauses) {
 
 		Assertions.notNull(clauses, "Clauses must not be null.");
 		return new ClausesBasedStatement(clauses, null);
@@ -83,8 +79,7 @@ public interface Statement extends Visitable {
 	 * @since 2021.3.0
 	 */
 	@API(status = STABLE, since = "2021.3.0")
-	@NotNull
-	static Statement usingPeriodic(Integer batchSize, @NotNull List<Clause> clauses) {
+	static Statement usingPeriodic(Integer batchSize, List<Clause> clauses) {
 
 		Assertions.notNull(clauses, "Clauses must not be null.");
 		Assertions.isTrue(!clauses.isEmpty(), "Clauses must not be empty.");
@@ -97,7 +92,6 @@ public interface Statement extends Visitable {
 	 *                              String, but a fully qualified String is ok as well.
 	 * @return An entry point into a statement that starts with a call to stored procedure.
 	 */
-	@NotNull @Contract(pure = true)
 	static OngoingStandaloneCallWithoutArguments call(String... namespaceAndProcedure) {
 
 		return new DefaultStatementBuilder.StandaloneCallBuilder(ProcedureName.from(namespaceAndProcedure));
@@ -110,7 +104,6 @@ public interface Statement extends Visitable {
 	 * @return An immutable object representing properties resolved in a statement together with their context and owner
 	 * @since 2023.1.0
 	 */
-	@NotNull @Contract(pure = true)
 	StatementCatalog getCatalog();
 
 	/**
@@ -124,14 +117,12 @@ public interface Statement extends Visitable {
 	 * @return A valid Cypher statement
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	String getCypher();
 
 	/**
 	 * @return The context of this statement, allowing access to parameter names etc.
 	 */
 	@API(status = INTERNAL, since = "2021.0.0")
-	@NotNull @Contract(pure = true)
 	StatementContext getContext();
 
 	/**
@@ -139,7 +130,6 @@ public interface Statement extends Visitable {
 	 *
 	 * @return True if literal parameters hav
 	 */
-	@Contract(pure = true)
 	boolean isRenderConstantsAsParameters();
 
 	/**
@@ -187,7 +177,6 @@ public interface Statement extends Visitable {
 		/**
 		 * @return Creates a statement that returns an explain plan for the original statement.
 		 */
-		@NotNull @Contract(pure = true)
 		default Statement explain() {
 			return DecoratedQuery.explain(this);
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -23,8 +23,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Collection;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.utils.Assertions;
@@ -72,8 +70,7 @@ public interface StatementBuilder
 		 * @neo4j.version 4.0.0
 		 */
 		@Neo4jVersion(minimum = "4.0.0")
-		@NotNull @Contract(pure = true)
-		Condition asCondition();
+			Condition asCondition();
 	}
 
 	/**
@@ -120,8 +117,8 @@ public interface StatementBuilder
 		 * @param variable The alias name
 		 * @return A normal, ongoing read.
 		 */
-		@NotNull @CheckReturnValue
-		OngoingReading as(@NotNull String variable);
+		@CheckReturnValue
+		OngoingReading as(String variable);
 
 		/**
 		 * Reuse an existing symbolic name.
@@ -130,7 +127,7 @@ public interface StatementBuilder
 		 * @return A normal, ongoing read.
 		 * @since 2021.0.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default OngoingReading as(SymbolicName variable) {
 			return as(variable.getValue());
 		}
@@ -164,8 +161,8 @@ public interface StatementBuilder
 		 * @param condition The new condition, must not be {@literal null}
 		 * @return A match restricted by a where clause with no return items yet.
 		 */
-		@NotNull @CheckReturnValue
-		OrderableOngoingReadingAndWithWithWhere where(@NotNull Condition condition);
+		@CheckReturnValue
+		OrderableOngoingReadingAndWithWithWhere where(Condition condition);
 
 		/**
 		 * Adds a where clause based on a path pattern to this match.
@@ -177,8 +174,8 @@ public interface StatementBuilder
 		 * @return A match restricted by a where clause with no return items yet.
 		 * @since 1.0.1
 		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithWhere where(@NotNull RelationshipPattern pathPattern) {
+		@CheckReturnValue
+		default OrderableOngoingReadingAndWithWithWhere where(RelationshipPattern pathPattern) {
 
 			Assertions.notNull(pathPattern, "The path pattern must not be null.");
 			return this.where(RelationshipPatternCondition.of(pathPattern));
@@ -230,8 +227,8 @@ public interface StatementBuilder
 		 * @param expression The expression that is added with an {@literal AND}
 		 * @return A new order specifying step.
 		 */
-		@NotNull @CheckReturnValue
-		TerminalOngoingOrderDefinition and(@NotNull Expression expression);
+		@CheckReturnValue
+		TerminalOngoingOrderDefinition and(Expression expression);
 	}
 
 	/**
@@ -247,7 +244,7 @@ public interface StatementBuilder
 		 *
 		 * @return The ongoing definition of a match
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingMatchAndReturnWithOrder descending();
 
 		/**
@@ -255,7 +252,7 @@ public interface StatementBuilder
 		 *
 		 * @return The ongoing definition of a match
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingMatchAndReturnWithOrder ascending();
 	}
 
@@ -273,8 +270,8 @@ public interface StatementBuilder
 		 * @param expression The expression that is added with an {@literal AND}
 		 * @return A new order specifying step.
 		 */
-		@NotNull @CheckReturnValue
-		OngoingOrderDefinition and(@NotNull Expression expression);
+		@CheckReturnValue
+		OngoingOrderDefinition and(Expression expression);
 	}
 
 	/**
@@ -289,7 +286,7 @@ public interface StatementBuilder
 		 *
 		 * @return The ongoing definition of a match
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingReadingAndWithWithWhereAndOrder descending();
 
 		/**
@@ -297,7 +294,7 @@ public interface StatementBuilder
 		 *
 		 * @return The ongoing definition of a match
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingReadingAndWithWithWhereAndOrder ascending();
 	}
 
@@ -312,14 +309,12 @@ public interface StatementBuilder
 		/**
 		 * @return The statement ready to be used, i.e. in a renderer.
 		 */
-		@NotNull @Contract(pure = true)
 		T build();
 
 		/**
 		 * @return Creates a statement that returns an explain plan for the original statement.
 		 * @since 2020.1.2
 		 */
-		@NotNull @Contract(pure = true)
 		default Statement explain() {
 
 			return DecoratedQuery.explain(build());
@@ -329,7 +324,6 @@ public interface StatementBuilder
 		 * @return Creates a profiled statement that includes both the result and the actually executed and profiled plan.
 		 * @since 2020.1.2
 		 */
-		@NotNull @Contract(pure = true)
 		default Statement profile() {
 
 			return DecoratedQuery.profile(build());
@@ -351,7 +345,7 @@ public interface StatementBuilder
 		 * @param sortItem One or more sort items
 		 * @return A build step that still offers methods for defining skip and limit
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingMatchAndReturnWithOrder orderBy(SortItem... sortItem);
 
 
@@ -363,7 +357,7 @@ public interface StatementBuilder
 		 * @return A build step that still offers methods for defining skip and limit
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingMatchAndReturnWithOrder orderBy(Collection<SortItem> sortItem);
 
 		/**
@@ -372,8 +366,8 @@ public interface StatementBuilder
 		 * @param expression The expression to order by
 		 * @return A step that allows for adding more expression or fine-tuning the sort direction of the last expression
 		 */
-		@NotNull @CheckReturnValue
-		TerminalOngoingOrderDefinition orderBy(@NotNull Expression expression);
+		@CheckReturnValue
+		TerminalOngoingOrderDefinition orderBy(Expression expression);
 	}
 
 	/**
@@ -389,7 +383,7 @@ public interface StatementBuilder
 		 * @param number How many records to skip. If this is null, then no records are skipped.
 		 * @return A step that only allows the limit of records to be specified.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		TerminalExposesLimit skip(Number number);
 
 		/**
@@ -399,7 +393,7 @@ public interface StatementBuilder
 		 * @return A step that only allows the limit of records to be specified.
 		 * @since 2021.0.0
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		TerminalExposesLimit skip(Expression expression);
 	}
 
@@ -416,7 +410,7 @@ public interface StatementBuilder
 		 * @param number How many records to return. If this is null, all the records are returned.
 		 * @return A buildable match statement.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableStatement<ResultStatement> limit(Number number);
 
 		/**
@@ -426,7 +420,7 @@ public interface StatementBuilder
 		 * @return A buildable match statement.
 		 * @since 2021.0.0
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableStatement<ResultStatement> limit(Expression expression);
 	}
 
@@ -454,7 +448,7 @@ public interface StatementBuilder
 		 * @param sortItem One or more sort items
 		 * @return A build step that still offers methods for defining skip and limit
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OrderableOngoingReadingAndWithWithWhere orderBy(SortItem... sortItem);
 
 		/**
@@ -465,7 +459,7 @@ public interface StatementBuilder
 		 * @return A build step that still offers methods for defining skip and limit
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OrderableOngoingReadingAndWithWithWhere orderBy(Collection<SortItem> sortItem);
 
 		/**
@@ -474,8 +468,8 @@ public interface StatementBuilder
 		 * @param expression The expression to order by
 		 * @return A step that allows for adding more expression or fine-tuning the sort direction of the last expression
 		 */
-		@NotNull @CheckReturnValue
-		OngoingOrderDefinition orderBy(@NotNull Expression expression);
+		@CheckReturnValue
+		OngoingOrderDefinition orderBy(Expression expression);
 	}
 
 	/**
@@ -498,7 +492,7 @@ public interface StatementBuilder
 		 * @param number How many records to skip. If this is null, then no records are skipped.
 		 * @return A step that only allows the limit of records to be specified.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingReadingAndWithWithSkip skip(Number number);
 
 		/**
@@ -508,7 +502,7 @@ public interface StatementBuilder
 		 * @return A step that only allows the limit of records to be specified.
 		 * @since 2021.0.0
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingReadingAndWithWithSkip skip(Expression expression);
 	}
 
@@ -525,7 +519,7 @@ public interface StatementBuilder
 		 * @param number How many records to return. If this is null, all the records are returned.
 		 * @return A buildable match statement.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingReadingAndWith limit(Number number);
 
 		/**
@@ -535,7 +529,7 @@ public interface StatementBuilder
 		 * @return A buildable match statement.
 		 * @since 2021.0.0
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingReadingAndWith limit(Expression expression);
 	}
 
@@ -552,8 +546,6 @@ public interface StatementBuilder
 		 * @return A step for selecting the source of iteration
 		 * @since 2023.4.0
 		 */
-		@NotNull
-		@Contract(pure = true)
 		ForeachSourceStep foreach(SymbolicName variable);
 	}
 
@@ -612,7 +604,7 @@ public interface StatementBuilder
 		 * @param variables Variables indicating the things to delete.
 		 * @return A match with a {@literal DELETE} clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default OngoingUpdate delete(String... variables) {
 			return delete(Expressions.createSymbolicNames(variables));
 		}
@@ -624,7 +616,7 @@ public interface StatementBuilder
 		 * @param variables Variables indicating the things to delete.
 		 * @return A match with a {@literal DELETE} clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default OngoingUpdate delete(Named... variables) {
 			return delete(Expressions.createSymbolicNames(variables));
 		}
@@ -635,7 +627,7 @@ public interface StatementBuilder
 		 * @param expressions The expressions to be deleted.
 		 * @return A match with a {@literal DELETE} clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingUpdate delete(Expression... expressions);
 
 		/**
@@ -645,7 +637,7 @@ public interface StatementBuilder
 		 * @return A match with a {@literal DELETE} clause that can be build now
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingUpdate delete(Collection<? extends Expression> expressions);
 
 		/**
@@ -655,7 +647,7 @@ public interface StatementBuilder
 		 * @param variables Variables indicating the things to delete.
 		 * @return A match with a {@literal DETACH DELETE} clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default OngoingUpdate detachDelete(String... variables) {
 			return detachDelete(Expressions.createSymbolicNames(variables));
 		}
@@ -667,7 +659,7 @@ public interface StatementBuilder
 		 * @param variables Variables indicating the things to delete.
 		 * @return A match with a {@literal DETACH DELETE} clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default OngoingUpdate detachDelete(Named... variables) {
 			return detachDelete(Expressions.createSymbolicNames(variables));
 		}
@@ -678,7 +670,7 @@ public interface StatementBuilder
 		 * @param expressions The expressions to be deleted.
 		 * @return A match with {@literal DETACH DELETE} clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingUpdate detachDelete(Expression... expressions);
 
 		/**
@@ -688,7 +680,7 @@ public interface StatementBuilder
 		 * @return A match with {@literal DETACH DELETE} clause that can be build now
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingUpdate detachDelete(Collection<? extends Expression> expressions);
 	}
 
@@ -706,7 +698,7 @@ public interface StatementBuilder
 		 * @param expressions The list of expressions to use in a set clause.
 		 * @return An ongoing match and update
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate set(Expression... expressions);
 
 		/**
@@ -717,7 +709,7 @@ public interface StatementBuilder
 		 * @return An ongoing match and update
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate set(Collection<? extends Expression> expressions);
 
 		/**
@@ -727,7 +719,7 @@ public interface StatementBuilder
 		 * @param expression The modifying expression
 		 * @return An ongoing match and update
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default BuildableMatchAndUpdate set(Named variable, Expression expression) {
 			return set(variable.getRequiredSymbolicName(), expression);
 		}
@@ -741,7 +733,7 @@ public interface StatementBuilder
 		 * @return An ongoing match and update
 		 * @since 2020.1.5
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate mutate(Expression target, Expression properties);
 
 		/**
@@ -753,7 +745,7 @@ public interface StatementBuilder
 		 * @return An ongoing match and update
 		 * @since 2020.1.5
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default BuildableMatchAndUpdate mutate(Named variable, Expression properties) {
 			return mutate(variable.getRequiredSymbolicName(), properties);
 		}
@@ -774,7 +766,7 @@ public interface StatementBuilder
 		 * @param labels The labels to be set
 		 * @return A match with a SET clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		R set(Node node, String... labels);
 
 		/**
@@ -785,7 +777,7 @@ public interface StatementBuilder
 		 * @return A match with a SET clause that can be build now
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		R set(Node node, Collection<String> labels);
 	}
 
@@ -803,7 +795,7 @@ public interface StatementBuilder
 		 * @param labels The labels to be removed
 		 * @return A match with a REMOVE clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate remove(Node node, String... labels);
 
 		/**
@@ -814,7 +806,7 @@ public interface StatementBuilder
 		 * @return A match with a REMOVE clause that can be build now
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate remove(Node node, Collection<String> labels);
 
 		/**
@@ -823,7 +815,7 @@ public interface StatementBuilder
 		 * @param properties The properties to be removed
 		 * @return A match with a REMOVE clause that can be build now
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate remove(Property... properties);
 
 		/**
@@ -833,7 +825,7 @@ public interface StatementBuilder
 		 * @return A match with a REMOVE clause that can be build now
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableMatchAndUpdate remove(Collection<Property> properties);
 	}
 
@@ -866,7 +858,7 @@ public interface StatementBuilder
 		 *
 		 * @return an ongoing definition of a merge action.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingMergeAction onCreate();
 
 		/**
@@ -874,7 +866,7 @@ public interface StatementBuilder
 		 *
 		 * @return an ongoing definition of a merge action.
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		OngoingMergeAction onMatch();
 	}
 
@@ -899,7 +891,7 @@ public interface StatementBuilder
 		 * @param expressions The list of expressions to use in a set clause.
 		 * @return An ongoing match and update
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableOngoingMergeAction set(Expression... expressions);
 
 		/**
@@ -910,7 +902,7 @@ public interface StatementBuilder
 		 * @return An ongoing match and update
 		 * @since 2021.2.2
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableOngoingMergeAction set(Collection<? extends Expression> expressions);
 
 		/**
@@ -920,7 +912,7 @@ public interface StatementBuilder
 		 * @param expression The modifying expression
 		 * @return An ongoing match and update
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default BuildableOngoingMergeAction set(Named variable, Expression expression) {
 			return set(variable.getRequiredSymbolicName(), expression);
 		}
@@ -934,7 +926,7 @@ public interface StatementBuilder
 		 * @return An ongoing match and update
 		 * @since 2020.1.5
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		BuildableOngoingMergeAction mutate(Expression target, Expression properties);
 
 		/**
@@ -946,7 +938,7 @@ public interface StatementBuilder
 		 * @return An ongoing match and update
 		 * @since 2020.1.5
 		 */
-		@NotNull @CheckReturnValue
+		@CheckReturnValue
 		default BuildableOngoingMergeAction mutate(Named variable, Expression properties) {
 			return mutate(variable.getRequiredSymbolicName(), properties);
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StringLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StringLiteral.java
@@ -26,7 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * The string representation of a string literal will be a quoted Cypher string in single tickmarks with
@@ -45,7 +44,6 @@ public final class StringLiteral extends LiteralBase<CharSequence> {
 		super(content);
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Subquery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Subquery.java
@@ -22,7 +22,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
 /**
@@ -101,7 +100,7 @@ public final class Subquery extends AbstractClause implements Clause {
 	 * {@return the importing with clause if any}
 	 */
 	@API(status = INTERNAL)
-	public @Nullable With importingWith() {
+	public With importingWith() {
 		var imports = this.importingWith == null ? null : this.importingWith.imports();
 		if (imports == null && statement instanceof ClausesBasedStatement cbs) {
 			return cbs.getClauses().stream().findFirst().filter(With.class::isInstance)

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SubqueryExpressionBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SubqueryExpressionBuilder.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can build counting sub-queries. Might be used in the future for existential sub-queries, too.
@@ -39,7 +38,6 @@ public interface SubqueryExpressionBuilder {
 	 * @return The immutable {@link CountExpression}
 	 * @since 2023.9.0
 	 */
-	@NotNull
 	CountExpression count(PatternElement requiredPattern, PatternElement... patternElement);
 
 	/**
@@ -49,7 +47,6 @@ public interface SubqueryExpressionBuilder {
 	 * @return The immutable {@link CountExpression}
 	 * @since 2023.9.0
 	 */
-	@NotNull
 	CountExpression count(Statement.UnionQuery union);
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
@@ -27,8 +27,6 @@ import java.util.Objects;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.neo4j.cypherdsl.core.utils.LRUCache;
 
@@ -88,7 +86,6 @@ public final class SymbolicName implements Expression, IdentifiableElement {
 	 * @param otherValue The value to concat.
 	 * @return A new symbolic name
 	 */
-	@NotNull @Contract(pure = true)
 	public SymbolicName concat(String otherValue) {
 
 		Assertions.notNull(otherValue, "Value to concat must not be null.");
@@ -106,7 +103,6 @@ public final class SymbolicName implements Expression, IdentifiableElement {
 	 * @return A map projection.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	public MapProjection project(List<Object> entries) {
 		return project(entries.toArray());
 	}
@@ -121,7 +117,6 @@ public final class SymbolicName implements Expression, IdentifiableElement {
 	 * @return A map projection.
 	 * @since 2021.0.0
 	 */
-	@NotNull @Contract(pure = true)
 	public MapProjection project(Object... entries) {
 		return MapProjection.create(this, entries);
 	}
@@ -152,7 +147,6 @@ public final class SymbolicName implements Expression, IdentifiableElement {
 		return value == null ? super.hashCode() : Objects.hash(value);
 	}
 
-	@NotNull
 	@Override
 	public Expression asExpression() {
 		return this;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/TemporalLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/TemporalLiteral.java
@@ -29,7 +29,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A literal representing a temporal value to be formatted in a way that Neo4j's Cypher understands it.
@@ -69,7 +68,6 @@ public final class TemporalLiteral extends LiteralBase<TemporalAccessor> {
 		this.value = String.format("%s('%s')", method, formatter.format(content));
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 		return value;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -43,8 +42,7 @@ public final class Where implements Visitable {
 	 * @return A {@literal WHERE} expression or null when {@code optionalWhere} has been {@literal NULL}
 	 * @since 2022.0.0
 	 */
-	@Nullable
-	public static Where from(@Nullable Expression optionalWhere) {
+	public static Where from(Expression optionalWhere) {
 		return optionalWhere == null ? null : new Where(optionalWhere.asCondition());
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/annotations/CheckReturnValue.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/annotations/CheckReturnValue.java
@@ -25,15 +25,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
 
 /**
  * Simple version of the JSR 305 annotation that allows detecting accidentally omitted calls to
  * {@link org.neo4j.cypherdsl.core.Cypher#match(org.neo4j.cypherdsl.core.PatternElement...)} ()} and the likes in IntelliJ.
  * <p>
  * This annotation is {@link org.apiguardian.api.API.Status#INTERNAL}. Clients should not rely on its presence.
- * The annotation may be replaced with a more suitable one by JetBrains, e.g.
- * the {@link Contract} annotation, when a favourable use-case can be found.
  *
  * @author Lukas Eder
  * @author Michael J. Simons

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/LoadCSV.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/LoadCSV.java
@@ -25,9 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Clause;
 
 /**
@@ -60,7 +57,7 @@ public final class LoadCSV implements Clause {
 		this(uri, withHeaders, alias, null);
 	}
 
-	private LoadCSV(URI uri, boolean withHeaders, String alias, @Nullable String fieldTerminator) {
+	private LoadCSV(URI uri, boolean withHeaders, String alias, String fieldTerminator) {
 		this.uri = uri;
 		this.withHeaders = withHeaders;
 		this.alias = alias;
@@ -84,7 +81,6 @@ public final class LoadCSV implements Clause {
 	/**
 	 * @return The field terminator to use
 	 */
-	@Nullable
 	public String getFieldTerminator() {
 		return fieldTerminator;
 	}
@@ -101,8 +97,7 @@ public final class LoadCSV implements Clause {
 	 * @param newFieldTerminator the new field terminator
 	 * @return A new instance or this instance if the terminator hasn't changed
 	 */
-	@NotNull @Contract(pure = true)
-	public LoadCSV withFieldTerminator(@Nullable final String newFieldTerminator) {
+	public LoadCSV withFieldTerminator(final String newFieldTerminator) {
 
 		String value = Optional.ofNullable(newFieldTerminator).map(String::trim)
 			.filter(v -> !v.isEmpty()).orElse(null);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/Namespace.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/Namespace.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core.internal;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.Literal;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
@@ -46,7 +45,6 @@ public final class Namespace implements Literal<String[]> {
 		visitor.leave(this);
 	}
 
-	@NotNull
 	@Override
 	public String asString() {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ReflectiveVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ReflectiveVisitor.java
@@ -34,8 +34,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.EnterResult;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
@@ -109,10 +107,9 @@ public abstract class ReflectiveVisitor extends VisitorWithResult {
 			return new PreEnterResult(handler);
 		}
 
-		@Nullable
-		private final Visitor delegate;
+			private final Visitor delegate;
 
-		private PreEnterResult(@Nullable Visitor delegate) {
+		private PreEnterResult(Visitor delegate) {
 			this.delegate = delegate;
 		}
 	}
@@ -229,7 +226,6 @@ public abstract class ReflectiveVisitor extends VisitorWithResult {
 	}
 
 	@SuppressWarnings("squid:S3011") // Very much the point of the whole thing
-	@NotNull
 	private static Method getMethodInPhaseWithActualVisitor(TargetAndPhase targetAndPhase, Class<?> visitorClass, Class<?> clazz) throws NoSuchMethodException {
 		Method method = visitorClass.getDeclaredMethod(targetAndPhase.phase.methodName, clazz);
 		method.setAccessible(true);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipPatternCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipPatternCondition.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core.internal;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Operator;
 import org.neo4j.cypherdsl.core.RelationshipPattern;
@@ -67,7 +66,6 @@ public final class RelationshipPatternCondition implements Condition {
 	}
 
 	@Override
-	@NotNull
 	public Condition not() {
 		return new RelationshipPatternCondition(!this.not, this.pathPattern);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -37,7 +37,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.Aliased;
 import org.neo4j.cypherdsl.core.AliasedExpression;
 import org.neo4j.cypherdsl.core.Asterisk;
@@ -343,7 +342,6 @@ public final class ScopingStrategy {
 			.anyMatch(identifiedBy(needle));
 	}
 
-	@NotNull
 	private static Predicate<IdentifiableElement> byHasAName() {
 		Predicate<IdentifiableElement> hasAName = Named.class::isInstance;
 		hasAName = hasAName.or(AliasedExpression.class::isInstance);
@@ -370,7 +368,6 @@ public final class ScopingStrategy {
 		return value;
 	}
 
-	@NotNull
 	private Predicate<String> identifiedBy(Named needle) {
 		return i -> {
 			boolean result = i.equals(needle.getRequiredSymbolicName().getValue());

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/UsingPeriodicCommit.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/UsingPeriodicCommit.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core.internal;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Neo4jVersion;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 
@@ -35,5 +34,5 @@ import org.neo4j.cypherdsl.core.ast.Visitable;
  */
 @API(status = INTERNAL, since = "2021.2.1")
 @Neo4jVersion(minimum = "3.5", last = "4.4")
-public record UsingPeriodicCommit(@Nullable Integer rate) implements Visitable {
+public record UsingPeriodicCommit(Integer rate) implements Visitable {
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.build.annotations.RegisterForReflection;
 import org.neo4j.cypherdsl.core.AliasedExpression;
 import org.neo4j.cypherdsl.core.Case;
@@ -614,7 +613,7 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 		if (!inRelationshipCondition || nameResolvingStrategy.isResolved(symbolicName)) {
 			if (Boolean.TRUE.equals(inPatternExpression.peek()) && !scopingStrategy.hasVisitedBefore(new Named() {
 				@Override
-				public @NotNull Optional<SymbolicName> getSymbolicName() {
+				public Optional<SymbolicName> getSymbolicName() {
 					return Optional.of(symbolicName);
 				}
 			})) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Comparison;
 import org.neo4j.cypherdsl.core.FunctionInvocation;
 import org.neo4j.cypherdsl.core.Subquery;
@@ -55,7 +54,7 @@ public enum Dialect {
 		private final DefaultNeo4j5HandlerSupplier handlerSupplier = new DefaultNeo4j5HandlerSupplier();
 
 		@Override
-		@Nullable Class<? extends Visitor> getHandler(Visitable visitable) {
+		Class<? extends Visitor> getHandler(Visitable visitable) {
 			return handlerSupplier.apply(visitable).orElseGet(() -> super.getHandler(visitable));
 		}
 	},
@@ -69,7 +68,7 @@ public enum Dialect {
 		private final DefaultNeo4j5HandlerSupplier handlerSupplier = new DefaultNeo4j5HandlerSupplierWithNewImportScopeSubquerySupport();
 
 		@Override
-		@Nullable Class<? extends Visitor> getHandler(Visitable visitable) {
+		Class<? extends Visitor> getHandler(Visitable visitable) {
 			return handlerSupplier.apply(visitable).orElseGet(() -> super.getHandler(visitable));
 		}
 	},
@@ -83,7 +82,7 @@ public enum Dialect {
 		private final DefaultNeo4j5HandlerSupplier handlerSupplier = new DefaultNeo4j5HandlerSupplierWithNewImportScopeSubquerySupport();
 
 		@Override
-		@Nullable Class<? extends Visitor> getHandler(Visitable visitable) {
+		Class<? extends Visitor> getHandler(Visitable visitable) {
 			return handlerSupplier.apply(visitable).orElseGet(() -> super.getHandler(visitable));
 		}
 
@@ -93,7 +92,7 @@ public enum Dialect {
 		}
 	};
 
-	@Nullable Class<? extends Visitor> getHandler(Visitable visitable) {
+	Class<? extends Visitor> getHandler(Visitable visitable) {
 		return null;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
 		<javapoet.version>1.13.0</javapoet.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<jaxb.version>2.3.1</jaxb.version>
-		<jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
 		<joda-time.version>2.14.0</joda-time.version>
 		<jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
 		<jsr305.version>3.0.2</jsr305.version>
@@ -327,13 +326,6 @@
 				<groupId>org.testcontainers</groupId>
 				<artifactId>neo4j</artifactId>
 				<version>${testcontainers.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jetbrains</groupId>
-				<artifactId>annotations</artifactId>
-				<version>${jetbrains-annotations.version}</version>
-				<scope>provided</scope>
-				<optional>true</optional>
 			</dependency>
 			<dependency>
 				<groupId>cglib</groupId>


### PR DESCRIPTION
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump mockito.version from 5.16.0 to 5.16.1 (#1201)**
- **build(deps): Bump neo4j.version from 5.26.3 to 5.26.4 (#1202)**
- **build(deps-dev): Bump com.google.guava:guava (#1203)**
- **build(deps): Bump com.mycila:license-maven-plugin from 4.6 to 5.0.0 (#1204)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1205)**
- **build(deps): Bump net.java.dev.jna:jna from 5.16.0 to 5.17.0 (#1206)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1208)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1210)**
- **build(deps): Bump org.junit:junit-bom from 5.12.0 to 5.12.1 (#1209)**
- **build(deps): Bump testcontainers.version from 1.20.5 to 1.20.6 (#1207)**
- **refactor: Deprecate all driver integrations from Cypher-DSL side. (#1211)**
- **build(deps): Bump org.ow2.asm:asm from 9.7.1 to 9.8 (#1212)**
- **build(deps): Bump joda-time:joda-time from 2.13.1 to 2.14.0 (#1213)**
- **build(deps): Bump org.sonarsource.scanner.maven:sonar-maven-plugin (#1214)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1215)**
- **build(deps-dev): Bump com.google.guava:guava (#1216)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1217)**
- **build(deps): Bump org.apache.maven.plugins:maven-surefire-plugin (#1218)**
- **build(deps): Bump org.asciidoctor:asciidoctor-maven-plugin (#1219)**
- **build(deps): Bump org.apache.maven.plugins:maven-failsafe-plugin (#1220)**
- **build(deps): Bump neo4j.version from 5.26.4 to 5.26.5 (#1221)**
- **build(deps): Bump mockito.version from 5.16.1 to 5.17.0 (#1222)**
- **build(deps): Bump org.asciidoctor:asciidoctorj-diagram (#1223)**
- **build(deps): Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13 (#1226)**
- **build(deps): Bump org.junit:junit-bom from 5.12.1 to 5.12.2 (#1228)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1229)**
- **build(deps-dev): Bump com.google.guava:guava (#1230)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1231)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1232)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1233)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump neo4j.version from 5.26.5 to 5.26.6 (#1236)**
- **build(deps): Bump testcontainers.version from 1.20.6 to 1.21.0 (#1238)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1240)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1241)**
- **build(deps-dev): Bump com.tngtech.archunit:archunit from 1.4.0 to 1.4.1 (#1243)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.10 to 5.11 (#1237)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1239)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver (#1242)**
- **refactor: Add better error messages when attempting to continue subquery without `with`.**
- **fix: Don't change simple case to generic case.**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump io.projectreactor:reactor-bom (#1246)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j from 7.4.5 to 7.5.0 (#1245)**
- **feat: Add support for `SHORTEST k`, `SHORTEST k GROUPS`, `ALL SHORTEST` and `ANY` path selectors. (#1247)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1248)**
- **build(deps): Bump mockito.version from 5.17.0 to 5.18.0 (#1249)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump testcontainers.version from 1.21.0 to 1.21.1 (#1250)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1251)**
- **build(deps): Bump org.junit:junit-bom from 5.12.2 to 5.13.0 (#1252)**
- **build(deps): Bump neo4j.version from 5.26.6 to 5.26.7 (#1253)**
- **build(deps): Bump org.codehaus.mojo:exec-maven-plugin (#1255)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11 to 5.11.1 (#1254)**
- **docs: Fix copyright date.**
- **build(deps): Bump org.junit:junit-bom from 5.13.0 to 5.13.1 (#1256)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1257)**
- **build(deps): Bump neo4j.version from 5.26.7 to 5.26.8 (#1258)**
- **build(deps): Bump org.codehaus.mojo:flatten-maven-plugin (#1267)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1259)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1260)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1261)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1262)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1264)**
- **build(deps): Bump org.asciidoctor:asciidoctorj-diagram (#1265)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11.1 to 5.11.2 (#1266)**
- **build(deps): Bump testcontainers.version from 1.21.1 to 1.21.2 (#1263)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1268)**
- **build(deps): Bump testcontainers.version from 1.21.2 to 1.21.3 (#1269)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1275)**
- **build(deps): Bump org.apache.maven.plugins:maven-enforcer-plugin (#1276)**
- **build(deps): Bump neo4j.version from 5.26.8 to 5.26.9 (#1278)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1272)**
- **build(deps): Bump org.junit:junit-bom from 5.13.1 to 5.13.3 (#1274)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver from 5.28.5 to 5.28.8 (#1277)**
- **build(deps): Bump org.moditect:moditect-maven-plugin (#1279)**
- **build(deps): Bump org.apache.maven.plugins:maven-enforcer-plugin (#1281)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1282)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1283)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1284)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1285)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver (#1280)**
- **build(deps): Bump org.junit:junit-bom from 5.13.3 to 5.13.4 (#1288)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1289)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11.2 to 5.12.0 (#1290)**
- **docs: Update changelog.**
- **Prepare release.**
- **refactor: Remove deprecated features and unnecessary suppressions. (#1292)**
- **refactor: Remove JetBrains annotations.**
