### PR TITLE
feat/make neo4j5 default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 :artifactId: neo4j-cypher-dsl
 
 // This will be next version and also the one that will be put into the manual for the main branch
-:neo4j-cypher-dsl-version: 2025.8.0-SNAPSHOT
+:neo4j-cypher-dsl-version: 2025.0.0-SNAPSHOT
 // This is the latest released version, used only in the readme
 :neo4j-cypher-dsl-version-latest: 2024.7.2
 

--- a/docs/static-meta-model/ogm-annotation-processor.adoc
+++ b/docs/static-meta-model/ogm-annotation-processor.adoc
@@ -14,7 +14,7 @@ Inside those classes `@Relationship`, `@Property`, `@StartNode` and `@EndNode` a
 
 The processor generates a static metamodel for each annotated class found in the same package with an underscore (`_`) added to the name.
 
-The processor needs Neo4j-OGM 4 and the Cypher-DSL in version `2025.8.0` or later on it's classpath.
+The processor needs Neo4j-OGM 4 and the Cypher-DSL in version `2025.0.0` or later on it's classpath.
 We recommend using it explicitly on the separate annotation processor classpath (via `--processor-path` to `javac`).
 
 The processor does *not* support nested classes used as `@NodeEntity` or `@RelationshipEntity`.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractMappingAnnotationProcessor.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractMappingAnnotationProcessor.java
@@ -56,7 +56,7 @@ import javax.tools.JavaFileObject;
  * ship with support for SDN6+ and Neo4j-OGM).
  *
  * @author Michael J. Simons
- * @since 2025.8.0
+ * @since 2025.0.0
  */
 public abstract class AbstractMappingAnnotationProcessor extends AbstractProcessor {
 

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-ogm/src/main/java/org/neo4j/cypherdsl/codegen/ogm/OGMAnnotationProcessor.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-ogm/src/main/java/org/neo4j/cypherdsl/codegen/ogm/OGMAnnotationProcessor.java
@@ -73,9 +73,9 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
  *
  * @author Shinigami92 (Christopher Quadflieg)
  * @author Michael J. Simons
- * @since 2025.8.0
+ * @since 2025.0.0
  */
-@API(status = EXPERIMENTAL, since = "2025.8.0")
+@API(status = EXPERIMENTAL, since = "2025.0.0")
 @SupportedAnnotationTypes({ OGMAnnotationProcessor.NODE_ENTITY_ANNOTATION,
 		OGMAnnotationProcessor.RELATIONSHIP_ENTITY_ANNOTATION })
 @SupportedOptions({ Configuration.PROPERTY_PREFIX, Configuration.PROPERTY_SUFFIX, Configuration.PROPERTY_INDENT_STYLE,

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
@@ -105,7 +105,7 @@ public final class Configuration {
 		this.alwaysEscapeNames = builder.alwaysEscapeNames;
 		this.indentStyle = builder.indentStyle;
 		this.indentSize = builder.indentSize;
-		this.dialect = (builder.dialect != null) ? builder.dialect : Dialect.NEO4J_4;
+		this.dialect = (builder.dialect != null) ? builder.dialect : Dialect.NEO4J_5_DEFAULT_CYPHER;
 		this.generatedNames = builder.generatedNames;
 		this.enforceSchema = builder.enforceSchema;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
@@ -125,7 +125,7 @@ public enum Dialect {
 	},
 
 	/**
-	 * Essentially the same as {@link #NEO4J_5_23} but also enabling the {@code CYPHER 5}
+	 * Essentially the same as {@link #NEO4J_5_23} but also enabling the {@code CYPHER 25}
 	 * prefix on generated statements. This dialect works on Neo4j 5.26 and higher.
 	 * Genrally, {@link #NEO4J_5_23} is preferable.
 	 *

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
@@ -60,7 +60,7 @@ public enum Dialect {
 
 	/**
 	 * Enhanced Neo4j 5 dialect that renders importing with statements for call subqueries
-	 * as variable scoped subqueries.
+	 * as variable scoped subqueries, suitable for Neo4j >= 5.23.
 	 *
 	 * @since 2024.1.0
 	 */
@@ -74,22 +74,85 @@ public enum Dialect {
 	},
 
 	/**
-	 * Essentially the same as {@link #NEO4J_5_23} but also enabling the {@code CYPHER 5}
-	 * preamble on generated statements.
-	 *
+	 * A Neo4j 5.26 and higher dialect that always renders the {@code CYPHER 5} prefix.
 	 * @since 2024.5.0
+	 * @deprecated Use {@link #NEO4J_5_CYPHER_5} if neccessary or
+	 * {@link #NEO4J_5_DEFAULT_CYPHER} in all other cases.
 	 */
+	@Deprecated(forRemoval = true)
 	NEO4J_5_26 {
-		private final DefaultNeo4j5HandlerSupplier handlerSupplier = new DefaultNeo4j5HandlerSupplierWithNewImportScopeSubquerySupport();
-
 		@Override
 		Class<? extends Visitor> getHandler(Visitable visitable) {
-			return this.handlerSupplier.apply(visitable).orElseGet(() -> super.getHandler(visitable));
+			return NEO4J_5_23.getHandler(visitable);
 		}
 
 		@Override
 		Optional<String> getPrefix() {
 			return Optional.of("CYPHER 5 ");
+		}
+	},
+
+	/**
+	 * Essentially the same as {@link #NEO4J_5_23} using the databases default Cypher
+	 * version. This is the default dialect for Cypher-DSL 2025.0.0 and onwards.
+	 *
+	 * @since 2025.0.0
+	 */
+	NEO4J_5_DEFAULT_CYPHER {
+		@Override
+		Class<? extends Visitor> getHandler(Visitable visitable) {
+			return NEO4J_5_23.getHandler(visitable);
+		}
+	},
+
+	/**
+	 * Essentially the same as {@link #NEO4J_5_23} but also enabling the {@code CYPHER 5}
+	 * prefix on generated statements. This dialect works on Neo4j 5.26 and higher.
+	 * Genrally, {@link #NEO4J_5_DEFAULT_CYPHER} is preferrable.
+	 *
+	 * @since 2025.0.0
+	 */
+	NEO4J_5_CYPHER_5 {
+		@Override
+		Class<? extends Visitor> getHandler(Visitable visitable) {
+			return NEO4J_5_23.getHandler(visitable);
+		}
+
+		@Override
+		Optional<String> getPrefix() {
+			return Optional.of("CYPHER 5 ");
+		}
+	},
+
+	/**
+	 * Essentially the same as {@link #NEO4J_5_23} but also enabling the {@code CYPHER 5}
+	 * prefix on generated statements. This dialect works on Neo4j 5.26 and higher.
+	 * Genrally, {@link #NEO4J_5_23} is preferable.
+	 *
+	 * @since 2025.0.0
+	 */
+	NEO4J_5_CYPHER_25 {
+		@Override
+		Class<? extends Visitor> getHandler(Visitable visitable) {
+			return NEO4J_5_23.getHandler(visitable);
+		}
+
+		@Override
+		Optional<String> getPrefix() {
+			return Optional.of("CYPHER 25 ");
+		}
+	},
+
+	/**
+	 * A placeholder for Neo4j 2025 calver. Same behaviour as
+	 * {@link #NEO4J_5_DEFAULT_CYPHER} in this version of Cypher-DSL.
+	 *
+	 * @since 2025.0.0
+	 */
+	NEO4J_2025 {
+		@Override
+		Class<? extends Visitor> getHandler(Visitable visitable) {
+			return NEO4J_5_23.getHandler(visitable);
 		}
 	};
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/Cypher5IT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/Cypher5IT.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Cypher5IT {
 
 	private final Renderer renderer = Renderer
-		.getRenderer(Configuration.newConfig().alwaysEscapeNames(false).withDialect(Dialect.NEO4J_5_26).build());
+		.getRenderer(Configuration.newConfig().alwaysEscapeNames(false).withDialect(Dialect.NEO4J_5_CYPHER_5).build());
 
 	@Test
 	void cypher5PrefixOnSimpleStatements() {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -1035,6 +1035,7 @@ class IssueRelatedIT {
 		assertThat(cypher).isEqualTo(expected);
 	}
 
+	@SuppressWarnings("removal")
 	@ParameterizedTest // GH-319
 	@EnumSource(Dialect.class)
 	void subqueryWithRename(Dialect dialect) {
@@ -1063,11 +1064,15 @@ class IssueRelatedIT {
 				  RETURN x
 				}
 				RETURN *""";
-		if (dialect == Dialect.NEO4J_5_23 || dialect == Dialect.NEO4J_5_26) {
+
+		if (EnumSet.complementOf(EnumSet.of(Dialect.NEO4J_4, Dialect.NEO4J_5)).contains(dialect)) {
 			expected = expected.replace("CALL {", "CALL (nodes) {").replace("  WITH nodes\n", "");
 		}
-		if (dialect == Dialect.NEO4J_5_26) {
+		if (EnumSet.of(Dialect.NEO4J_5_26, Dialect.NEO4J_5_CYPHER_5).contains(dialect)) {
 			expected = "CYPHER 5 " + expected;
+		}
+		else if (EnumSet.of(Dialect.NEO4J_5_CYPHER_25).contains(dialect)) {
+			expected = "CYPHER 25 " + expected;
 		}
 		assertThat(cypher).isEqualTo(expected);
 	}


### PR DESCRIPTION
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump mockito.version from 5.16.0 to 5.16.1 (#1201)**
- **build(deps): Bump neo4j.version from 5.26.3 to 5.26.4 (#1202)**
- **build(deps-dev): Bump com.google.guava:guava (#1203)**
- **build(deps): Bump com.mycila:license-maven-plugin from 4.6 to 5.0.0 (#1204)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1205)**
- **build(deps): Bump net.java.dev.jna:jna from 5.16.0 to 5.17.0 (#1206)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1208)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1210)**
- **build(deps): Bump org.junit:junit-bom from 5.12.0 to 5.12.1 (#1209)**
- **build(deps): Bump testcontainers.version from 1.20.5 to 1.20.6 (#1207)**
- **refactor: Deprecate all driver integrations from Cypher-DSL side. (#1211)**
- **build(deps): Bump org.ow2.asm:asm from 9.7.1 to 9.8 (#1212)**
- **build(deps): Bump joda-time:joda-time from 2.13.1 to 2.14.0 (#1213)**
- **build(deps): Bump org.sonarsource.scanner.maven:sonar-maven-plugin (#1214)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1215)**
- **build(deps-dev): Bump com.google.guava:guava (#1216)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1217)**
- **build(deps): Bump org.apache.maven.plugins:maven-surefire-plugin (#1218)**
- **build(deps): Bump org.asciidoctor:asciidoctor-maven-plugin (#1219)**
- **build(deps): Bump org.apache.maven.plugins:maven-failsafe-plugin (#1220)**
- **build(deps): Bump neo4j.version from 5.26.4 to 5.26.5 (#1221)**
- **build(deps): Bump mockito.version from 5.16.1 to 5.17.0 (#1222)**
- **build(deps): Bump org.asciidoctor:asciidoctorj-diagram (#1223)**
- **build(deps): Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13 (#1226)**
- **build(deps): Bump org.junit:junit-bom from 5.12.1 to 5.12.2 (#1228)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1229)**
- **build(deps-dev): Bump com.google.guava:guava (#1230)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1231)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1232)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1233)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump neo4j.version from 5.26.5 to 5.26.6 (#1236)**
- **build(deps): Bump testcontainers.version from 1.20.6 to 1.21.0 (#1238)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1240)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1241)**
- **build(deps-dev): Bump com.tngtech.archunit:archunit from 1.4.0 to 1.4.1 (#1243)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.10 to 5.11 (#1237)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1239)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver (#1242)**
- **refactor: Add better error messages when attempting to continue subquery without `with`.**
- **fix: Don't change simple case to generic case.**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump io.projectreactor:reactor-bom (#1246)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j from 7.4.5 to 7.5.0 (#1245)**
- **feat: Add support for `SHORTEST k`, `SHORTEST k GROUPS`, `ALL SHORTEST` and `ANY` path selectors. (#1247)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1248)**
- **build(deps): Bump mockito.version from 5.17.0 to 5.18.0 (#1249)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump testcontainers.version from 1.21.0 to 1.21.1 (#1250)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1251)**
- **build(deps): Bump org.junit:junit-bom from 5.12.2 to 5.13.0 (#1252)**
- **build(deps): Bump neo4j.version from 5.26.6 to 5.26.7 (#1253)**
- **build(deps): Bump org.codehaus.mojo:exec-maven-plugin (#1255)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11 to 5.11.1 (#1254)**
- **docs: Fix copyright date.**
- **build(deps): Bump org.junit:junit-bom from 5.13.0 to 5.13.1 (#1256)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1257)**
- **build(deps): Bump neo4j.version from 5.26.7 to 5.26.8 (#1258)**
- **build(deps): Bump org.codehaus.mojo:flatten-maven-plugin (#1267)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1259)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1260)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1261)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1262)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1264)**
- **build(deps): Bump org.asciidoctor:asciidoctorj-diagram (#1265)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11.1 to 5.11.2 (#1266)**
- **build(deps): Bump testcontainers.version from 1.21.1 to 1.21.2 (#1263)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1268)**
- **build(deps): Bump testcontainers.version from 1.21.2 to 1.21.3 (#1269)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1275)**
- **build(deps): Bump org.apache.maven.plugins:maven-enforcer-plugin (#1276)**
- **build(deps): Bump neo4j.version from 5.26.8 to 5.26.9 (#1278)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1272)**
- **build(deps): Bump org.junit:junit-bom from 5.13.1 to 5.13.3 (#1274)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver from 5.28.5 to 5.28.8 (#1277)**
- **build(deps): Bump org.moditect:moditect-maven-plugin (#1279)**
- **build(deps): Bump org.apache.maven.plugins:maven-enforcer-plugin (#1281)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1282)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1283)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1284)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1285)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver (#1280)**
- **build(deps): Bump org.junit:junit-bom from 5.13.3 to 5.13.4 (#1288)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1289)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11.2 to 5.12.0 (#1290)**
- **docs: Update changelog.**
- **Prepare release.**
- **refactor: Remove deprecated features and unnecessary suppressions. (#1292)**
- **refactor: Remove JetBrains annotations. (#1294)**
- **docs: Remove executable statement example; add back the QueryDSLAdapterTest for inclusion. (#1295)**
- **feat: Add an annotation processor for Neo4j-OGM annotations. (#1287)**
- **Polishing. (#1296)**
- **build(deps): Bump org.codehaus.mojo:flatten-maven-plugin (#1297)**
- **build(deps): Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 (#1299)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle from 10.26.1 to 11.0.0 (#1301)**
- **build(deps): Bump neo4j.version from 5.26.9 to 5.26.10 (#1302)**
- **build(deps): Bump org.apache.maven.plugins:maven-javadoc-plugin (#1303)**
- **build(deps): Bump mockito.version from 5.18.0 to 5.19.0 (#1304)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1305)**
- **build(deps): Bump quarkus.platform.version from 3.24.5 to 3.25.3 (#1306)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1307)**
- **refactor: Use Spring-Java-Formatter and corresponding checkstyle config. (#1308)**
- **refactor: Remove the remaining bits of driver dependencies.**
- **Remove superflous .editorconfig**
- **refactor: Make Neo4j 5 the default dialect, promote the usage of a dialect without Cypher prefix.**
