### PR TITLE
feat/dynlabels remove

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -491,6 +491,13 @@ class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, Ongoin
 	}
 
 	@Override
+	public BuildableMatchAndUpdate remove(Node node, Labels labels) {
+
+		this.closeCurrentOngoingUpdate();
+		return new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, Operations.remove(node, labels));
+	}
+
+	@Override
 	public final OngoingReadingWithWhere where(Condition newCondition) {
 
 		if (this.currentOngoingMatch == null) {
@@ -1404,6 +1411,12 @@ class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, Ongoin
 		}
 
 		@Override
+		public BuildableMatchAndUpdate remove(Node node, Labels labels) {
+
+			return DefaultStatementBuilder.this.addWith(buildWith()).remove(node, labels);
+		}
+
+		@Override
 		public BuildableMatchAndUpdate remove(Property... properties) {
 
 			return DefaultStatementBuilder.this.addWith(buildWith()).remove(properties);
@@ -1710,6 +1723,15 @@ class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, Ongoin
 		public BuildableMatchAndUpdate remove(Node node, Collection<String> labels) {
 
 			return remove(node, labels.toArray(new String[] {}));
+		}
+
+		@Override
+		public BuildableMatchAndUpdate remove(Node node, Labels labels) {
+
+			DefaultStatementWithUpdateBuilder result = DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(
+					UpdateType.REMOVE, Operations.remove(node, labels));
+			DefaultStatementBuilder.this.addUpdatingClause(this.builder.build());
+			return result;
 		}
 
 		@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
@@ -164,7 +164,7 @@ final class Operations {
 	 * @param target the target of the new labels
 	 * @param labels the labels to be added
 	 * @return a set operation
-	 * @since 2021.2.3
+	 * @since 2025.1.0
 	 */
 	static Operation set(Node target, Labels labels) {
 
@@ -181,6 +181,18 @@ final class Operations {
 	static Operation remove(Node target, String... label) {
 
 		return Operation.create(target, Operator.REMOVE_LABEL, label);
+	}
+
+	/**
+	 * Creates an operation removing one or more labels from a given {@link Node node}.
+	 * @param node the node from which the labels should be removed
+	 * @param labels the labels to be removed
+	 * @return a remove operation
+	 * @since 2025.1.0
+	 */
+	static Expression remove(Node node, Labels labels) {
+
+		return Operation.create(node, Operator.REMOVE_LABEL, labels);
 	}
 
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -854,6 +854,16 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 		BuildableMatchAndUpdate remove(Node node, Collection<String> labels);
 
 		/**
+		 * Creates {@code SET} clause for removing the given labels from a node.
+		 * @param node the node whose labels are to be changed
+		 * @param labels the labels to be removed
+		 * @return a match with a REMOVE clause that can be build now
+		 * @since 2025.1.0
+		 */
+		@CheckReturnValue
+		BuildableMatchAndUpdate remove(Node node, Labels labels);
+
+		/**
 		 * Creates {@code SET} clause for removing the enumerated properties.
 		 * @param properties the properties to be removed
 		 * @return a match with a REMOVE clause that can be build now


### PR DESCRIPTION
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump mockito.version from 5.16.0 to 5.16.1 (#1201)**
- **build(deps): Bump neo4j.version from 5.26.3 to 5.26.4 (#1202)**
- **build(deps-dev): Bump com.google.guava:guava (#1203)**
- **build(deps): Bump com.mycila:license-maven-plugin from 4.6 to 5.0.0 (#1204)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1205)**
- **build(deps): Bump net.java.dev.jna:jna from 5.16.0 to 5.17.0 (#1206)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1208)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1210)**
- **build(deps): Bump org.junit:junit-bom from 5.12.0 to 5.12.1 (#1209)**
- **build(deps): Bump testcontainers.version from 1.20.5 to 1.20.6 (#1207)**
- **refactor: Deprecate all driver integrations from Cypher-DSL side. (#1211)**
- **build(deps): Bump org.ow2.asm:asm from 9.7.1 to 9.8 (#1212)**
- **build(deps): Bump joda-time:joda-time from 2.13.1 to 2.14.0 (#1213)**
- **build(deps): Bump org.sonarsource.scanner.maven:sonar-maven-plugin (#1214)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1215)**
- **build(deps-dev): Bump com.google.guava:guava (#1216)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1217)**
- **build(deps): Bump org.apache.maven.plugins:maven-surefire-plugin (#1218)**
- **build(deps): Bump org.asciidoctor:asciidoctor-maven-plugin (#1219)**
- **build(deps): Bump org.apache.maven.plugins:maven-failsafe-plugin (#1220)**
- **build(deps): Bump neo4j.version from 5.26.4 to 5.26.5 (#1221)**
- **build(deps): Bump mockito.version from 5.16.1 to 5.17.0 (#1222)**
- **build(deps): Bump org.asciidoctor:asciidoctorj-diagram (#1223)**
- **build(deps): Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13 (#1226)**
- **build(deps): Bump org.junit:junit-bom from 5.12.1 to 5.12.2 (#1228)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1229)**
- **build(deps-dev): Bump com.google.guava:guava (#1230)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1231)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1232)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1233)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump neo4j.version from 5.26.5 to 5.26.6 (#1236)**
- **build(deps): Bump testcontainers.version from 1.20.6 to 1.21.0 (#1238)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1240)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1241)**
- **build(deps-dev): Bump com.tngtech.archunit:archunit from 1.4.0 to 1.4.1 (#1243)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.10 to 5.11 (#1237)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1239)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver (#1242)**
- **refactor: Add better error messages when attempting to continue subquery without `with`.**
- **fix: Don't change simple case to generic case.**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump io.projectreactor:reactor-bom (#1246)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j from 7.4.5 to 7.5.0 (#1245)**
- **feat: Add support for `SHORTEST k`, `SHORTEST k GROUPS`, `ALL SHORTEST` and `ANY` path selectors. (#1247)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1248)**
- **build(deps): Bump mockito.version from 5.17.0 to 5.18.0 (#1249)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump testcontainers.version from 1.21.0 to 1.21.1 (#1250)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1251)**
- **build(deps): Bump org.junit:junit-bom from 5.12.2 to 5.13.0 (#1252)**
- **build(deps): Bump neo4j.version from 5.26.6 to 5.26.7 (#1253)**
- **build(deps): Bump org.codehaus.mojo:exec-maven-plugin (#1255)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11 to 5.11.1 (#1254)**
- **docs: Fix copyright date.**
- **build(deps): Bump org.junit:junit-bom from 5.13.0 to 5.13.1 (#1256)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1257)**
- **build(deps): Bump neo4j.version from 5.26.7 to 5.26.8 (#1258)**
- **build(deps): Bump org.codehaus.mojo:flatten-maven-plugin (#1267)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1259)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1260)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1261)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1262)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1264)**
- **build(deps): Bump org.asciidoctor:asciidoctorj-diagram (#1265)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11.1 to 5.11.2 (#1266)**
- **build(deps): Bump testcontainers.version from 1.21.1 to 1.21.2 (#1263)**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump com.puppycrawl.tools:checkstyle (#1268)**
- **build(deps): Bump testcontainers.version from 1.21.2 to 1.21.3 (#1269)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1275)**
- **build(deps): Bump org.apache.maven.plugins:maven-enforcer-plugin (#1276)**
- **build(deps): Bump neo4j.version from 5.26.8 to 5.26.9 (#1278)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1272)**
- **build(deps): Bump org.junit:junit-bom from 5.13.1 to 5.13.3 (#1274)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver from 5.28.5 to 5.28.8 (#1277)**
- **build(deps): Bump org.moditect:moditect-maven-plugin (#1279)**
- **build(deps): Bump org.apache.maven.plugins:maven-enforcer-plugin (#1281)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1282)**
- **build(deps): Bump org.graalvm.buildtools:native-maven-plugin (#1283)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1284)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1285)**
- **build(deps-dev): Bump org.neo4j.driver:neo4j-java-driver (#1280)**
- **build(deps): Bump org.junit:junit-bom from 5.13.3 to 5.13.4 (#1288)**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1289)**
- **build(deps-dev): Bump com.opencsv:opencsv from 5.11.2 to 5.12.0 (#1290)**
- **docs: Update changelog.**
- **Prepare release.**
- **refactor: Remove deprecated features and unnecessary suppressions. (#1292)**
- **refactor: Remove JetBrains annotations. (#1294)**
- **docs: Remove executable statement example; add back the QueryDSLAdapterTest for inclusion. (#1295)**
- **feat: Add an annotation processor for Neo4j-OGM annotations. (#1287)**
- **Polishing. (#1296)**
- **build(deps): Bump org.codehaus.mojo:flatten-maven-plugin (#1297)**
- **build(deps): Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 (#1299)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle from 10.26.1 to 11.0.0 (#1301)**
- **build(deps): Bump neo4j.version from 5.26.9 to 5.26.10 (#1302)**
- **build(deps): Bump org.apache.maven.plugins:maven-javadoc-plugin (#1303)**
- **build(deps): Bump mockito.version from 5.18.0 to 5.19.0 (#1304)**
- **build(deps): Bump io.projectreactor:reactor-bom (#1305)**
- **build(deps): Bump quarkus.platform.version from 3.24.5 to 3.25.3 (#1306)**
- **build(deps): Bump org.springframework.data:spring-data-neo4j (#1307)**
- **refactor: Use Spring-Java-Formatter and corresponding checkstyle config. (#1308)**
- **refactor: Remove the remaining bits of driver dependencies.**
- **Remove superflous .editorconfig**
- **refactor: Make Neo4j 5 the default dialect, promote the usage of a dialect without Cypher prefix.**
- **fix: Clearing the scoping strategy could lead to a premature resolution of symbolic names.**
- **fix: Improve rendering of the importing `CALL` clause.**
- **fix: Make Neo4j 5.26 latest the default dialectp proper.**
- **feat: Enhance old dialects to render `ALL SHORTEST` and `SHORTEST 1` as legacy functions.**
- **docs: Update changelog.**
- **Prepare release.**
- **build(deps): Bump org.springframework.boot:spring-boot-starter-parent (#1311)**
- **build(deps): Bump quarkus.platform.version from 3.25.3 to 3.25.4 (#1312)**
- **build(deps): Bump com.puppycrawl.tools:checkstyle from 11.0.0 to 11.0.1 (#1315)**
- **build(deps): Bump com.fasterxml.jackson:jackson-bom (#1316)**
- **build(deps): Bump org.jreleaser:jreleaser-maven-plugin (#1317)**
- **build(deps): Bump org.sonarsource.scanner.maven:sonar-maven-plugin (#1318)**
- **build(deps): Bump neo4j.version from 5.26.10 to 5.26.11 (#1319)**
- **build(deps): Bump quarkus.platform.version from 3.25.4 to 3.26.1 (#1320)**
- **build(deps-dev): Bump org.checkerframework:checker-qual (#1321)**
- **refactor: Existential subqueries in latest Neo4j do work with multiple matches, too. (#1322)**
- **docs: Update changelog.**
- **Prepare release.**
- **chore: Restore `QueryDSLAdapterTests` once again.**
- **feat: Add support for dynamic label expressions. (#1323)**
- **feat: Add support for dynamic label expression in the `SET` clause. (#1324)**
- **feat: Add support for dynamic label expression in the `REMOVE` clause.**
